### PR TITLE
[FIX] website_product_pack: Show proper price of pack components in Cart

### DIFF
--- a/website_product_pack/README.rst
+++ b/website_product_pack/README.rst
@@ -18,6 +18,9 @@ This module extend packs funcionality to website sale.
 
 NOTE: We highly recommend to install l10n_ar_website_sale module in order to fix problem with the product price (will use lst_price instead of list_price)
 
+1. Compatibile with allow modify option: this will let the user to
+   add/modfy/remove components of a Component detailed price's pack from the cart.
+
 Installation
 ============
 

--- a/website_product_pack/__manifest__.py
+++ b/website_product_pack/__manifest__.py
@@ -20,7 +20,7 @@
 
 {
     'name': 'Website Product Pack',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.2.0',
     'category': 'Website',
     'author': 'ADHOC SA, Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/website_product_pack/__manifest__.py
+++ b/website_product_pack/__manifest__.py
@@ -20,7 +20,7 @@
 
 {
     'name': 'Website Product Pack',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'category': 'Website',
     'author': 'ADHOC SA, Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/website_product_pack/models/__init__.py
+++ b/website_product_pack/models/__init__.py
@@ -6,3 +6,4 @@
 from . import product_template
 from . import sale_order
 from . import website
+from . import product_pack_line

--- a/website_product_pack/models/product_pack_line.py
+++ b/website_product_pack/models/product_pack_line.py
@@ -1,0 +1,27 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+
+class ProductPackLine(models.Model):
+
+    _inherit = 'product.pack.line'
+
+    @api.multi
+    def get_sale_order_line_vals(self, line, order):
+        """ Overwrite in order to proper show it in website cart. There we do
+        not show the discount column so we wan to show the price_unit with the
+        discount included.
+        """
+        self.ensure_one()
+        vals = super(ProductPackLine, self).get_sale_order_line_vals(
+            line, order)
+        if self._context.get('website_id', False):
+            vals.update({
+                'price_unit': vals['price_unit'] * (
+                    1.0 - vals['discount']/100),
+                'discount': 0.0,
+            })
+        return vals

--- a/website_product_pack/views/templates.xml
+++ b/website_product_pack/views/templates.xml
@@ -15,7 +15,7 @@
         </xpath>
 
         <xpath expr="//a[hasclass('js_delete_product')]" position="attributes">
-            <attribute name="t-if">not line.pack_parent_line_id</attribute>
+            <attribute name="t-if">not (line.pack_parent_line_id and not line.pack_parent_line_id.product_id.allow_modify_pack) and True or False</attribute>
         </xpath>
 
     </template>


### PR DESCRIPTION
Cart does not show discount information, for that reason we now shoe
price_unit + discount in the price unit of each componennt in the pack

This way make sence the price of each components with the sale order total.