### PR TITLE
[MIG] website_sale_product_description: change field's location and installable

### DIFF
--- a/website_sale_product_description/README.rst
+++ b/website_sale_product_description/README.rst
@@ -14,7 +14,7 @@
 Unique Description for E-commerce
 =================================
 
-Odoo has a sales description field that is used in e-commerce and sales orders. If you activate this option, a new field is created in products thath will only be used for e-commerce. 
+Odoo has a sales description field that is used in e-commerce and sales orders. If this module is installed, a new description field is created in products thath will only be used for e-commerce.
 
 
 Installation
@@ -36,7 +36,7 @@ Usage
 
 To use this module, you need to:
 
-#. Go to a Product, and you will see in 'Notes' page a 'Description for Website' text field
+#. Go to a Product template, and you will see in 'eCommerce' tab a 'Description for Website' text field
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/website_sale_product_description/__manifest__.py
+++ b/website_sale_product_description/__manifest__.py
@@ -31,5 +31,5 @@
         'views/product_template_views.xml',
         'views/product_template_templates.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/website_sale_product_description/views/product_template_views.xml
+++ b/website_sale_product_description/views/product_template_views.xml
@@ -3,11 +3,11 @@
     <record model="ir.ui.view" id="product_template_form_view">
         <field name="name">product.template.website.sale.product.description.form</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="inherit_id" ref="website_sale.product_template_form_view"/>
         <field name="arch" type="xml">
-            <group name="description" position="inside">
-                <group string="Description for Website">
-                    <field name="description_website" nolabel="1" placeholder="Note to be displayed on e-commerce..."/>
+            <group name="extra_images" position="after">
+                <group name="description_website" string="Description for Website">
+                    <field name="description_website" nolabel="1" placeholder="Description to be displayed on product's page..."/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
Since v12 product templates have an eCommerce tab when website_sale is installed, so it's convenient to place the field on that tab, and not in Sales as it was before.