### PR TITLE
[ADD] website_doc: enable docpage css class to all the documentation pages

### DIFF
--- a/website_doc/views/website_doc_toc_templates.xml
+++ b/website_doc/views/website_doc_toc_templates.xml
@@ -68,7 +68,7 @@
 
     <template id="documentation_post" name="Documentation Page">
         <t t-call="website.layout">
-            <div id="wrap" class="oe_structure mt16 mb16">
+            <div id="wrap" class="oe_structure mt16 mb16 docpage">
                 <div class="container">
                     <div class="row">
                         <ol class="breadcrumb mb0">
@@ -112,7 +112,7 @@
                     <t t-if="not titles or not titles[0].dont_show_childs" t-call="website_doc.toc"/>
                 </div>
                 <div class="container">
-                    <div t-field='toc.content' class="oe_structure docpage"/>
+                    <div t-field='toc.content' class="oe_structure"/>
                     <t t-raw="toc.google_doc"/>
                     <div t-if="toc.is_article">
                         <h2 class="page-header">También dentro de "<span t-field="toc.parent_id.name"/>


### PR DESCRIPTION
So if we change the look and feel of the documentation pages, not only in the articles, this also apply in the topic's pages and breadcrumb, and the footer section of the documentation.