### PR TITLE
[FIX] website_doc: convert doc title, buttons into rows

### DIFF
--- a/website_doc/__manifest__.py
+++ b/website_doc/__manifest__.py
@@ -21,7 +21,7 @@
     'name': 'Website Documentation',
     'category': 'Website',
     'summary': 'Website, Documentation',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/website_doc/views/website_doc_toc_templates.xml
+++ b/website_doc/views/website_doc_toc_templates.xml
@@ -85,7 +85,7 @@
                     </div>
                 </div>
                 <div class="container" id="doc-page">
-                    <div class="pull-right css_editable_mode_hidden" groups="base.group_user">
+                    <div class="row mt32 pull-right css_editable_mode_hidden" groups="base.group_user">
                       <ul class="list-inline">
                         <li>
                           <p t-field='toc.state'/>
@@ -95,7 +95,7 @@
                         </li>
                       </ul>
                     </div>
-                    <h1 class="page-header">
+                    <h1 class="page-header row mt32" style="margin-top: 40px !important;">
                         <t t-esc="toc and toc.name or 'Documentation'"/>
                         <t t-if="toc.is_article">
                             <t t-call="website_doc.article_read_status">


### PR DESCRIPTION
This way we avoid the problem of the overlaṕing between the content of
the article/menu, the the search bar and doc title that were two close.