### PR TITLE
[FIX] Sale order prices are wrong when using discounts and allow_modi…

### DIFF
--- a/website_product_pack/models/sale_order.py
+++ b/website_product_pack/models/sale_order.py
@@ -14,9 +14,7 @@ class SaleOrder(models.Model):
         self, product_id=None,
             line_id=None, add_qty=0, set_qty=0, **kwargs):
         sale_order_line = self.env['sale.order.line'].browse(line_id)
-        if sale_order_line.pack_parent_line_id and not \
-           sale_order_line.pack_parent_line_id.product_id.allow_modify_pack \
-           == 'frontend_backend':
+        if sale_order_line.pack_parent_line_id:
             return {
                 'line_id': line_id,
                 'quantity': sale_order_line.product_uom_qty}


### PR DESCRIPTION
In order to replicate issue:
* Install Adhoc's `product_pack` and `website_product_pack`
* Create a product template with a given tax, and 0 as price.
* Make that template a pack, and add a pack line with discount. The added product should have a different tax as the pack so it's easier to visualize, also it should be associated to some pricelist discount.
* For the template option **Allow mofify pack** choose `Backend and Frontend`
* Attempt to buy that pack on the website. The prices shown in the checkout will be correct, but in the payment section the pack's discount will be gone.