### PR TITLE
[FIX] l10n_ar_website_sale: remove repeated City in address website form when the user is not login yet

### DIFF
--- a/l10n_ar_website_sale/__manifest__.py
+++ b/l10n_ar_website_sale/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'e-Commerce Argentina Partner Document',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/l10n_ar_website_sale/views/l10n_ar_website_sale_templates.xml
+++ b/l10n_ar_website_sale/views/l10n_ar_website_sale_templates.xml
@@ -50,12 +50,6 @@
                 </div>
             </t>
         </t>
-
-        <div t-attf-class="form-group #{error.get('city') and 'o_has_error' or ''} col-md-8 div_city">
-            <label class="col-form-label" for="city">City</label>
-            <input type="text" name="city" t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}" t-att-value="'city' in checkout and checkout['city']"/>
-        </div>
-
     </template>
 
     <template id="cart_lines" name="Shopping Cart Lines" inherit_id="website_sale.cart_lines">


### PR DESCRIPTION
task 20021

Before

![image](https://user-images.githubusercontent.com/7593953/74435106-7969b400-4e42-11ea-90c0-99c19605bb23.png)

After

![image](https://user-images.githubusercontent.com/7593953/74435113-7e2e6800-4e42-11ea-874c-da669269b159.png)
