### PR TITLE
[MIG] payment_todopago: Migration to 13.0

### DIFF
--- a/payment_todopago/__manifest__.py
+++ b/payment_todopago/__manifest__.py
@@ -21,7 +21,7 @@
     'name': 'TodoPago Payment Acquirer',
     'category': 'Hidden',
     'summary': 'Payment Acquirer: TodoPago Implementation',
-    'version': '12.0.1.0.0',
+    'version': '13.0.1.0.0',
     'author': 'Moldeo Interactive - www.moldeo.coop,ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',
@@ -47,6 +47,6 @@
     ],
     'demo': [
     ],
-    'installable': False,
+    'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
 }

--- a/payment_todopago/data/payment_acquirer_data.xml
+++ b/payment_todopago/data/payment_acquirer_data.xml
@@ -6,7 +6,7 @@
         <field name="provider">todopago</field>
         <field name="company_id" ref="base.main_company"/>
         <field name="view_template_id" ref="todopago_form"/>
-        <field name="environment">test</field>
+        <field name="state">test</field>
         <field name="fees_active" eval="True"/>
         <!-- till we fix this button in sales orders -->
         <!--<field name="validation">automatic</field>-->
@@ -18,9 +18,11 @@
 <p>Only available in Argentina and in ARS. You will be redirected to the Todopago website after cliking on the payment button.</p>]]></field>
         <field name="pending_msg"><![CDATA[
 <p>Pendiente de acreditación. Su pago todavía no ha sido confirmado por Mercadopago, le informaremos cuando esto suceda y validaremos el pedido.</p>]]></field>
+        <!-- TODO need to see where we can add this again
         <field name="error_msg"><![CDATA[
 <p>Error: Hubo un error en el pago, por favor comuniquese con nosotros.</p>]]></field>
-        <field name="image" type="base64" file="payment_todopago/static/description/icon.png"/>
+        -->
+        <field name="image_128" type="base64" file="payment_todopago/static/description/icon.png"/>
     </record>
 
 </odoo>

--- a/payment_todopago/models/payment_transaction.py
+++ b/payment_todopago/models/payment_transaction.py
@@ -53,12 +53,10 @@ class TxTodoPago(models.Model):
         transaction.todopago_Answer = Answer
         return transaction
 
-    @api.multi
     def _todopago_form_get_invalid_parameters(self, data):
         invalid_parameters = []
         return invalid_parameters
 
-    @api.multi
     def _todopago_form_validate(self, data):
         """
         """
@@ -77,10 +75,10 @@ class TxTodoPago(models.Model):
             return True
         # we need to get answer form todopago
         todopago_client_id = self.acquirer_id.todopago_client_id \
-            if self.acquirer_id.environment == 'prod' \
+            if self.acquirer_id.self.state == 'enabled' \
             else self.acquirer_id.todopago_test_client_id
         todopago_secret_key = self.acquirer_id.todopago_secret_key \
-            if self.acquirer_id.environment == 'prod' \
+            if self.acquirer_id.self.state == 'enabled' \
             else self.acquirer_id.todopago_test_secret_key
 
         answer_data = {


### PR DESCRIPTION
* remove api
* mask as installable
* environment field does not exist anymore, use instead state = {'enabled', 'test'}
* remove error_msg field from acquirer this one does not exist anymore