### PR TITLE
[FIX] payment_mercadopago: use mp 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 html2text
-mercadopago
+mercadopago===1.1.1
 suds-jurko
 requests


### PR DESCRIPTION
With the release of mp 1.2.0 the integration is broken with a loop