### PR TITLE
[REM] website_sale_ux: search custom behaviour

### DIFF
--- a/website_sale_ux/README.rst
+++ b/website_sale_ux/README.rst
@@ -18,8 +18,8 @@ Website Sale UX
 #. This module also changes the functionality of the Catalog page`s "Add to cart" buttons (frontend):
     * If the product has not variants, when user clicks Add to cart button then the product is added to the Cart (default behaviour).
     * If the product has variants, when users click the Add to cart button then they are redirected to the Product page (new feature) so they could choice among all variants, instead of opening the pop-up to choice among all variants (default behaviour). This new feature is required because "variant pop-up" shows a malfunction when user tries to add to cart a bigger quantity of a variant product than stock available.
-#. By default the frontend eCommerce search bar searches among all products when user is on Catalog page and browsing All products category, but if user is browsing an specific product category then the search bar searchs among this category`s products only. This module improves the searching of frontend eCommerce search bar by allowing the users all the time to search among all products no matter which product category is browsing at that moment. This function works when user press enter but not with dropdown pre-search results.
 #. By default, on Settings > Website the option Customer account (which set Free sign up option or By invitation on website) is not able. This module adds this setting option per website.
+#. Rename "All products" to "All categories" in categories left snippet on shop
 
 Installation
 ============

--- a/website_sale_ux/README.rst
+++ b/website_sale_ux/README.rst
@@ -20,6 +20,7 @@ Website Sale UX
     * If the product has variants, when users click the Add to cart button then they are redirected to the Product page (new feature) so they could choice among all variants, instead of opening the pop-up to choice among all variants (default behaviour). This new feature is required because "variant pop-up" shows a malfunction when user tries to add to cart a bigger quantity of a variant product than stock available.
 #. By default, on Settings > Website the option Customer account (which set Free sign up option or By invitation on website) is not able. This module adds this setting option per website.
 #. Rename "All products" to "All categories" in categories left snippet on shop
+#. Add an option to disable returning categories on shop search bar. To do so you need to go to website settings and check option "Disable Categories Search"
 
 Installation
 ============

--- a/website_sale_ux/controllers/main.py
+++ b/website_sale_ux/controllers/main.py
@@ -2,23 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.addons.sale_product_configurator.controllers.main import ProductConfiguratorController
-from odoo import http
 from odoo.http import request
-
-
-class WebsiteSaleCustom(WebsiteSale):
-
-    @http.route()
-    # TODO make optional
-    def shop(self, page=0, category=None, search='', ppg=False, **post):
-        """
-        If we have a search and category, clean category
-        """
-        if category and search:
-            category = None
-        return super().shop(page=page, category=category, search=search, ppg=ppg, **post)
 
 
 class ProductConfiguratorControllerCustom(ProductConfiguratorController):

--- a/website_sale_ux/models/__init__.py
+++ b/website_sale_ux/models/__init__.py
@@ -3,3 +3,4 @@
 # directory
 ##############################################################################
 from . import res_config_settings
+from . import website

--- a/website_sale_ux/models/res_config_settings.py
+++ b/website_sale_ux/models/res_config_settings.py
@@ -2,11 +2,13 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, api
+from odoo import models, api, fields
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
+
+    disable_categories_search = fields.Boolean(related='website_id.disable_categories_search', readonly=False)
 
     @api.model
     def _inverse_account_on_checkout(self):

--- a/website_sale_ux/models/website.py
+++ b/website_sale_ux/models/website.py
@@ -1,0 +1,28 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, tools, fields
+
+
+class Website(models.Model):
+
+    _inherit = "website"
+
+    disable_categories_search = fields.Boolean()
+
+    def _search_get_details(self, search_type, order, options):
+        res = super(Website, self)._search_get_details(search_type, order, options)
+        if search_type == 'products' and self.sudo()._get_disable_categories_search():
+            # borrar el elemento no es lo más elegante pero no vi otra forma facil
+            # de heredar. no es caro en temas de performance ya que el metodo super
+            # es super liviano (no hace busquedas ni nada)
+            for idx, item in enumerate(res):
+                if item.get('model') == 'product.public.category':
+                    res.pop(idx)
+        return res
+
+    @tools.ormcache('self.id')
+    def _get_disable_categories_search(self):
+        self.ensure_one()
+        return self.disable_categories_search

--- a/website_sale_ux/views/product_template_views.xml
+++ b/website_sale_ux/views/product_template_views.xml
@@ -21,4 +21,9 @@
             </a>
         </xpath>
     </template>
+    <template id="products_categories_list" inherit_id="website_sale.products_categories_list">
+        <label class="form-check-label fw-normal" t-att-for="all_products" position="replace">
+            <label class="form-check-label fw-normal" t-att-for="all_products">All Categories</label>
+        </label>
+    </template>
 </odoo>

--- a/website_sale_ux/views/res_config_settings_views.xml
+++ b/website_sale_ux/views/res_config_settings_views.xml
@@ -25,6 +25,19 @@
                     </div>
                 </div>
             </xpath>
+            <div id="sale_product_catalog_settings">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="disable_categories_search"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="disable_categories_search"/>
+                        <div class="text-muted">
+                            Disable search by categories on shop searchbar
+                        </div>
+                    </div>
+                </div>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
En16 nos quedo un hibrido de cosas que no es para lo cual había sido diseñada la funcionalidad. En el pasado habíamos toquetado cosas para lograr este comportamiento: a) al buscar por algo se elimina filtro de categorías b) al hacer click en "todos los productos" se elimina por que se estaba filtrando

Como esta hoy "b" no funciona y además se termina rompiendo algo adicional, que es que si uno buscó por algo y cambia las categorías, ese cambio no funciona y queda muy raro.

Volvemos a comportamiento nativo de odoo donde la busqueda aplica sobre el filtro de las categorías y cambiar de categorías NO resetea filtro de búsqueda. Renombramos "all products" por "all categories" para que sea mas representativo con este comportamiento.