### PR TITLE
[FIX] l10n_ar_website_sale_ux: b2c hide subtotal

### DIFF
--- a/l10n_ar_website_sale_ux/README.rst
+++ b/l10n_ar_website_sale_ux/README.rst
@@ -15,7 +15,7 @@ l10n_ar Website Sale UX
 =======================
 
 #. This module adds a "(+ tax)" legend next to the product price on the ecommerce product and product_item views for b2b customers
-#. This module also hides the tax discrimination line on the cart checkout page for b2c customers.
+#. This module also hides the tax discrimination line on the cart checkout page for b2c customers, also the subtotal line that is only show it un the b2b website
 
 Installation
 ============

--- a/l10n_ar_website_sale_ux/__manifest__.py
+++ b/l10n_ar_website_sale_ux/__manifest__.py
@@ -20,7 +20,7 @@
 {
     'name': 'l10n_ar Website Sale UX',
     'category': 'base.module_category_knowledge_management',
-    'version': "16.0.1.0.0",
+    'version': "16.0.1.1.0",
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/l10n_ar_website_sale_ux/views/l10n_ar_website_sale_hide_taxes.xml
+++ b/l10n_ar_website_sale_ux/views/l10n_ar_website_sale_hide_taxes.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
   <template id="website_sale_hide_taxes" name="Hide Taxes" inherit_id="website_sale.total">
-    <xpath expr="//tr[@id='order_total_untaxed']//span" position="attributes">
+    <tr id="order_total_untaxed" position="attributes">
       <attribute name="groups">account.group_show_line_subtotals_tax_excluded</attribute>
-      <attribute name="t-field">website_sale_order.amount_untaxed</attribute>
-    </xpath>
-    <xpath expr="//tr[@id='order_total_untaxed']//span" position="after">
-      <span t-field="website_sale_order.amount_total" groups="account.group_show_line_subtotals_tax_included" class="monetary_field" style="white-space: nowrap;" t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
-    </xpath>
+    </tr>
     <tr id='order_total_taxes' position="attributes">
       <attribute name="groups">account.group_show_line_subtotals_tax_excluded</attribute>
     </tr>


### PR DESCRIPTION
Subtotal info in website forms only have sense when we show the detail about the taxes (B2B)