### PR TITLE
[FIX]l10n_ar_website_sale_ux: hide taxes with d-none instead of t-if

### DIFF
--- a/l10n_ar_website_sale_ux/__manifest__.py
+++ b/l10n_ar_website_sale_ux/__manifest__.py
@@ -20,7 +20,7 @@
 {
     'name': 'l10n_ar Website Sale UX',
     'category': 'base.module_category_knowledge_management',
-    'version': "17.0.1.0.0",
+    'version': "17.0.1.1.0",
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/l10n_ar_website_sale_ux/views/l10n_ar_website_sale_hide_taxes.xml
+++ b/l10n_ar_website_sale_ux/views/l10n_ar_website_sale_hide_taxes.xml
@@ -2,10 +2,10 @@
 <odoo>
   <template id="website_sale_hide_taxes" name="Hide Taxes" inherit_id="website_sale.total">
     <tr id="order_total_untaxed" position="attributes">
-      <attribute name="t-if">request.env['website'].browse(website.id).show_line_subtotals_tax_selection == 'tax_excluded'</attribute>
+      <attribute name="t-attf-class">#{request.env['website'].browse(website.id).show_line_subtotals_tax_selection == 'tax_excluded' and '' or 'd-none'}</attribute>
     </tr>
     <tr id='order_total_taxes' position="attributes">
-      <attribute name="t-if">request.env['website'].browse(website.id).show_line_subtotals_tax_selection == 'tax_excluded'</attribute>
+      <attribute name="t-attf-class">#{request.env['website'].browse(website.id).show_line_subtotals_tax_selection == 'tax_excluded' and '' or 'd-none'}</attribute>
     </tr>
   </template>
 </odoo>


### PR DESCRIPTION
to prevent error with innerHTML 