### PR TITLE
[FIX]google_tag_manager_advanced_tracking, facebook_pixel_tracking

### DIFF
--- a/facebook_pixel_tracking/static/src/js/website_sale_tracking.js
+++ b/facebook_pixel_tracking/static/src/js/website_sale_tracking.js
@@ -71,12 +71,15 @@ PaymentForm.include({
 
     // @override
     _submitForm: async function (ev) {
-        const info = $("#o_wsale_accordion_item")[0].dataset.purchase_info;
-        const dict = {
-            'event':'purchase',
-            'ecommerce':info
+        const info_div = $("#o_wsale_accordion_item")[0]
+        if(info_div){
+            const info = info_div.dataset.purchase_info;
+            const dict = {
+                'event':'purchase',
+                'ecommerce':info
+            }
+            this._pushInfo(dict);
         }
-        this._pushInfo('OnPurchaseConfirm', dict);
         this._super(...arguments);
     },
 })

--- a/google_tag_manager_advanced_tracking/static/src/js/website_sale_tracking.js
+++ b/google_tag_manager_advanced_tracking/static/src/js/website_sale_tracking.js
@@ -76,12 +76,15 @@ PaymentForm.include({
     },
     // @override
     _submitForm: async function (ev) {
-        const info = $("#o_wsale_accordion_item")[0].dataset.purchase_info;
-        const dict = {
-            'event':'purchase',
-            'ecommerce':info
+        const info_div = $("#o_wsale_accordion_item")[0]
+        if(info_div){
+            const info = info_div.dataset.purchase_info;
+            const dict = {
+                'event':'purchase',
+                'ecommerce':info
+            }
+            this._pushInfo(dict);
         }
-        this._pushInfo(dict);
         this._super(...arguments);
     },
 })


### PR DESCRIPTION
on url /my/payment_method the view called for payment button is the same one as the ecommerce checkout, and there's no cart summary in this page.
Issue occured in both google_tag_manager_advanced_tracking and facebook_pixel_tracking modules