### PR TITLE
[FIX] website_sale_cancel_quotations: add a context

### DIFF
--- a/website_sale_cancel_quotations/models/sale_order.py
+++ b/website_sale_cancel_quotations/models/sale_order.py
@@ -10,4 +10,4 @@ class SaleOrder(models.Model):
 
     def _cron_clean_old_quotations(self, website=None):
         website = bool(self.env['ir.config_parameter'].sudo().get_param('website_sale_ux.cancel_old_website_quotations', False))
-        super()._cron_clean_old_quotations(website=website)
+        super(SaleOrder, self.with_context(website_installed=True))._cron_clean_old_quotations(website=website)


### PR DESCRIPTION
send a contex beacause if website isn't installed and we add in the domain website_id = or != False is a bug baceuse the field don't exist in the so