### PR TITLE
[IMP]website_sale_ux: show first variant SKU

### DIFF
--- a/website_sale_ux/__manifest__.py
+++ b/website_sale_ux/__manifest__.py
@@ -20,7 +20,7 @@
 {
     "name": "Website Sale UX",
     "category": "base.module_category_knowledge_management",
-    "version": "18.0.2.2.0",
+    "version": "18.0.2.3.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/website_sale_ux/views/templates.xml
+++ b/website_sale_ux/views/templates.xml
@@ -2,15 +2,15 @@
 <odoo>
     <template id="website_internal_ref_products_item" inherit_id="website_sale.products_item" name="Website Products Item Internal Ref" active="False">
         <xpath expr="//div[hasclass('o_wsale_product_sub')]" position="before">
-            <p t-if="product.default_code" class="text-muted small">
-                <span>Ref. interna: </span><span t-esc='product.default_code'/>
+            <p t-if="product.product_variant_id.default_code" class="text-muted small">
+                <span>Ref. interna: </span><span t-esc='product.product_variant_id.default_code'/>
             </p>
         </xpath>
     </template>
     <template id="website_internal_ref_product" inherit_id="website_sale.product" name="Website Product Internal Ref" active="False">
         <xpath expr="//div[@id='product_details']" position="inside">
-            <p t-if="product.default_code" class="text-muted small">
-                <b><span>Ref. interna: </span></b><span t-esc='product.default_code'/>
+            <p t-if="product.product_variant_count == 1 and product.product_variant_id.default_code" class="text-muted small">
+                <b><span>Ref. interna: </span></b><span t-esc='product.product_variant_id.default_code'/>
             </p>
         </xpath>
     </template>


### PR DESCRIPTION
now we show in /shop the SKU of selected variant (1st variant), and in /shop/[product_id] we only show the SKU if there's only one variant available