### PR TITLE
[ADD] new Module website_crawler_no_track

### DIFF
--- a/website_crawler_no_track/__init__.py
+++ b/website_crawler_no_track/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/website_crawler_no_track/__manifest__.py
+++ b/website_crawler_no_track/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Website Crawler No Track",
+    "version": "18.0.1.0.0",
+    "category": "Website",
+    "sequence": 14,
+    "summary": "",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "website",
+    ],
+    "data": [],
+    "installable": True,
+    "application": False,
+}

--- a/website_crawler_no_track/models/__init__.py
+++ b/website_crawler_no_track/models/__init__.py
@@ -1,0 +1,1 @@
+from . import website_visitor

--- a/website_crawler_no_track/models/website_visitor.py
+++ b/website_crawler_no_track/models/website_visitor.py
@@ -1,0 +1,19 @@
+from odoo import models
+from odoo.http import request
+
+
+class WebsiteVisitor(models.Model):
+    _inherit = "website.visitor"
+
+    def _get_visitor_from_request(self, force_create=False, force_track_values=None):
+        user_agent = request.httprequest.environ.get("HTTP_USER_AGENT")
+        crawlers_names = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("website.crawlers_names", "OAI-SearchBot,crawler,Googlebot,Amazonbot,bingbot,PetalBot,AhrefsBot")
+            .split(",")
+        )
+        if user_agent and any(crawler in user_agent for crawler in crawlers_names):
+            return self.env["website.visitor"]
+
+        return super()._get_visitor_from_request(force_create=force_create, force_track_values=force_track_values)


### PR DESCRIPTION
This module prevents tracking information from being added for requests with user agents matching specified crawler names. Its purpose is to avoid unnecessary resource consumption caused by intensive requests from web crawlers.