### PR TITLE
Remove suds-jurko (incompatible with Python 3 / Odoo 19)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 html2text
-suds-jurko
 requests


### PR DESCRIPTION
suds-jurko is not compatible with Python versions used by Odoo 19.
It breaks Odoo.sh builds during dependency installation.

This PR removes suds-jurko from requirements.txt to restore successful builds.