### PR TITLE
[MIG] website_sale_hide_all_prices: migrar a 19.0

### DIFF
--- a/website_sale_hide_all_prices/README.rst
+++ b/website_sale_hide_all_prices/README.rst
@@ -35,7 +35,7 @@ Usage
 
 To use this module, you need to:
 
-#. Just use the module.
+#. Just use the module..
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/website_sale_hide_all_prices/__manifest__.py
+++ b/website_sale_hide_all_prices/__manifest__.py
@@ -20,11 +20,15 @@
 {
     "name": "Website Sale Hide All Prices",
     "category": "website",
-    "version": "18.0.2.0.0",
+    "version": "19.0.1.0.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
-    "depends": ["website_sale_ux"],
+    "depends": [
+        "website_sale_ux",
+        "website_sale_comparison",
+        "website_sale_wishlist",
+    ],
     "images": [],
     "data": [
         "views/res_config_settings_views.xml",
@@ -35,7 +39,11 @@
             "website_sale_hide_all_prices/static/src/components/add_to_cart_notification.xml",
             "website_sale_hide_all_prices/static/src/components/add_to_cart_notification.js",
             "website_sale_hide_all_prices/static/src/components/product_configurator_dialog.js",
+            "website_sale_hide_all_prices/static/src/components/product_comparison_row.xml",
+            "website_sale_hide_all_prices/static/src/components/product_comparison_row.js",
+            "website_sale_hide_all_prices/static/src/components/product_template_attribute_line.xml",
+            "website_sale_hide_all_prices/static/src/components/product_template_attribute_line.js",
         ]
     },
-    "installable": False,
+    "installable": True,
 }

--- a/website_sale_hide_all_prices/controllers/main.py
+++ b/website_sale_hide_all_prices/controllers/main.py
@@ -1,3 +1,5 @@
+import json
+
 from odoo import http
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.http import request
@@ -21,3 +23,104 @@ class WebsiteSale(WebsiteSale):
         if order and order.website_id.website_hide_all_prices:
             payment_values["submit_button_label"] = _("Request Quotation")
         return payment_values
+
+    def _confirm_quotation_request(self, order_sudo):
+        """Finalize a quotation request (no payment).
+
+        The cart is left as a draft quotation for the sales team to follow up
+        on; its last id is stashed for the thank-you page and the cart session
+        is reset so the customer gets a fresh cart.
+        """
+        order_sudo._recompute_cart()
+        request.session["sale_last_order_id"] = order_sudo.id
+        request.website.sale_reset()
+
+    @http.route(
+        ["/shop/request_quotation"],
+        type="http",
+        auth="public",
+        methods=["POST"],
+        website=True,
+        sitemap=False,
+    )
+    def shop_request_quotation(self, **post):
+        """Skip the payment step when the website hides all prices.
+
+        Instead of routing the customer through /shop/payment (there is no real
+        payment for a quotation request), confirm the quotation request and land
+        the customer on the 'request received' thank-you page. Used as a fallback
+        for customers that reach /shop/checkout directly (e.g. logged-in users
+        with a saved address).
+        """
+        order_sudo = request.cart
+
+        if redirection := self._check_cart_and_addresses(order_sudo):
+            return redirection
+
+        # If the module is not active for this website, keep the native flow.
+        if not (order_sudo.website_id and order_sudo.website_id.website_hide_all_prices):
+            return request.redirect("/shop/payment")
+
+        self._confirm_quotation_request(order_sudo)
+        return request.redirect("/request-quotation")
+
+    @http.route(
+        ["/shop/address/submit"],
+        type="http",
+        methods=["POST"],
+        auth="public",
+        website=True,
+        sitemap=False,
+    )
+    def shop_address_submit(
+        self,
+        partner_id=None,
+        address_type="billing",
+        use_delivery_as_billing=None,
+        callback=None,
+        **form_data,
+    ):
+        """Bypass the intermediate /shop/checkout step for quotation websites.
+
+        Once the address form is saved and the cart's addresses are complete,
+        confirm the quotation request and redirect straight to the thank-you
+        page instead of the checkout review step. Falls back to the native flow
+        when the module is inactive, an explicit callback was requested, the
+        save failed, or the addresses are still incomplete.
+        """
+        result = super().shop_address_submit(
+            partner_id=partner_id,
+            address_type=address_type,
+            use_delivery_as_billing=use_delivery_as_billing,
+            callback=callback,
+            **form_data,
+        )
+
+        order_sudo = request.cart
+        # Respect an explicit callback (e.g. editing an address from elsewhere)
+        # and only act for websites that hide all prices.
+        if callback or not (order_sudo and order_sudo.website_id.website_hide_all_prices):
+            return result
+
+        # The @route-decorated parent returns a wrapped Response, not the raw
+        # JSON string; read its body to inspect/rewrite the feedback.
+        if isinstance(result, str):
+            body = result
+        elif hasattr(result, "get_data"):
+            body = result.get_data(as_text=True)
+        else:
+            return result
+        try:
+            feedback = json.loads(body)
+        except (TypeError, ValueError):
+            return result  # Not a JSON feedback (e.g. a redirect): keep native flow.
+
+        if feedback.get("invalid_fields") or not feedback.get("redirectUrl"):
+            return result  # Save failed: keep the native error handling.
+
+        if self._check_cart_and_addresses(order_sudo):
+            return result  # Addresses still incomplete: keep the native flow.
+
+        self._confirm_quotation_request(order_sudo)
+        feedback["redirectUrl"] = "/request-quotation"
+        return json.dumps(feedback)

--- a/website_sale_hide_all_prices/static/src/components/add_to_cart_notification.js
+++ b/website_sale_hide_all_prices/static/src/components/add_to_cart_notification.js
@@ -1,17 +1,11 @@
-/** @odoo-module **/
-
 import { session } from "@web/session";
 import { AddToCartNotification } from "@website_sale/js/notification/add_to_cart_notification/add_to_cart_notification";
-import { CartNotification } from "@website_sale/js/notification/cart_notification/cart_notification";
-import { WarningNotification } from "@website_sale/js/notification/warning_notification/warning_notification";
+import { patch } from "@web/core/utils/patch";
 
-class MyAddToCartNotification extends AddToCartNotification {
-    setup(){
-        super.setup();
-        this.props['website_hide_all_prices'] = session['website_hide_all_prices']
-    }
-}
+patch(AddToCartNotification.prototype, {
+    get websiteHideAllPrices() {
+        return !!session.website_hide_all_prices;
+    },
+});
 
-CartNotification.components = { AddToCartNotification: MyAddToCartNotification , WarningNotification  }
-
-MyAddToCartNotification.template = 'website_sale_hide_all_prices.MyAddToCartNotification'
+AddToCartNotification.template = "website_sale_hide_all_prices.MyAddToCartNotification";

--- a/website_sale_hide_all_prices/static/src/components/add_to_cart_notification.xml
+++ b/website_sale_hide_all_prices/static/src/components/add_to_cart_notification.xml
@@ -1,23 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-     <t t-name="website_sale_hide_all_prices.MyAddToCartNotification">
-           <div class="row g-2 mb-2" t-foreach="props.lines" t-as="line" t-key="line.id">
-            <div class="col-3">
-                <img class="img o_image_64_max rounded mb-2 img-fluid"
-                    t-att-src="line.image_url"
-                    t-att-alt="line.name"/>
-            </div>
-            <div class="col-6 d-flex flex-column align-items-start">
-                <span t-out="getProductSummary(line)"/>
-                <span class="text-muted small"
-                    t-if="line.description"
-                    t-out="line.description"/>
-            </div>
-            <div t-if="!props.website_hide_all_prices" class="col-3 d-flex flex-column align-items-end gap-1"
-                t-out="getFormattedPrice(line)"/>
+
+    <t t-name="website_sale_hide_all_prices.MyAddToCartNotification">
+        <div
+            class="d-flex flex-column gap-2 mb-2 mt-1"
+            t-foreach="mainLines"
+            t-as="line"
+            t-key="line.id"
+        >
+            <t t-call="website_sale_hide_all_prices.cartLine"/>
         </div>
         <a role="button" class="w-100 btn btn-primary" href="/shop/cart">
             View cart
         </a>
     </t>
+
+    <t t-name="website_sale_hide_all_prices.cartLine">
+        <div class="d-flex gap-3">
+            <div class="position-relative">
+                <div class="o_cart_product_image">
+                    <img
+                        class="img o_image_64_max rounded mb-2 img-fluid"
+                        t-att-src="line.image_url"
+                        t-att-alt="line.name"
+                    />
+                </div>
+                <span
+                    class="o_cart_item_count badge bg-secondary position-absolute top-0 start-100 translate-middle"
+                    t-out="line.quantity"
+                />
+            </div>
+            <div class="d-flex flex-column align-items-start flex-grow-1">
+                <span t-out="line.name"/>
+                <span
+                    t-if="line.combination_name"
+                    class="text-muted small"
+                    t-out="line.combination_name"
+                />
+                <span t-if="line.description" class="text-muted small" t-out="line.description"/>
+                <span t-out="line.uom_name" class="badge mt-1 bg-light"/>
+            </div>
+            <div
+                t-if="!line.linked_line_id and !websiteHideAllPrices"
+                class="col-3 d-flex flex-column align-items-end gap-1"
+                t-out="getFormattedPrice(line)"
+            />
+        </div>
+        <div
+            class="d-flex ps-5"
+            t-foreach="getLinkedLines(line.id)"
+            t-as="linkedLine"
+            t-key="linkedLine.id"
+        >
+            <t t-call="website_sale_hide_all_prices.cartLine">
+                <t t-set="line" t-value="linkedLine"/>
+            </t>
+        </div>
+    </t>
+
 </templates>

--- a/website_sale_hide_all_prices/static/src/components/product_comparison_row.js
+++ b/website_sale_hide_all_prices/static/src/components/product_comparison_row.js
@@ -1,0 +1,9 @@
+import { ProductRow } from "@website_sale_comparison/js/product_row/product_row";
+import { patch } from "@web/core/utils/patch";
+import { session } from "@web/session";
+
+patch(ProductRow.prototype, {
+    get websiteHideAllPrices() {
+        return !!session.website_hide_all_prices;
+    },
+});

--- a/website_sale_hide_all_prices/static/src/components/product_comparison_row.xml
+++ b/website_sale_hide_all_prices/static/src/components/product_comparison_row.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_sale_hide_all_prices.ProductRow"
+       t-inherit="website_sale_comparison.ProductRow"
+       t-inherit-mode="extension">
+        <xpath expr="//small[@t-if='!props.prevent_zero_price_sale']" position="attributes">
+            <attribute name="t-if">!props.prevent_zero_price_sale and !websiteHideAllPrices</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/website_sale_hide_all_prices/static/src/components/product_configurator_dialog.js
+++ b/website_sale_hide_all_prices/static/src/components/product_configurator_dialog.js
@@ -1,17 +1,13 @@
-/** @odoo-module **/
-
 import { useSubEnv } from "@odoo/owl";
-import { ProductConfiguratorDialog } from '@sale/js/product_configurator_dialog/product_configurator_dialog';
-import { patch } from '@web/core/utils/patch';
+import { ProductConfiguratorDialog } from "@sale/js/product_configurator_dialog/product_configurator_dialog";
+import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
 patch(ProductConfiguratorDialog.prototype, {
-   setup() {
+    setup() {
         super.setup(...arguments);
-        this.props['website_hide_all_prices'] = session['website_hide_all_prices']
-
         useSubEnv({
-            showPrice: !this.props.website_hide_all_prices ?? true,
+            showPrice: !session.website_hide_all_prices,
         });
     },
 });

--- a/website_sale_hide_all_prices/static/src/components/product_template_attribute_line.js
+++ b/website_sale_hide_all_prices/static/src/components/product_template_attribute_line.js
@@ -1,0 +1,17 @@
+import { ProductTemplateAttributeLine } from "@sale/js/product_template_attribute_line/product_template_attribute_line";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductTemplateAttributeLine.prototype, {
+    /**
+     * Drop the "(+ $X)" extra-price suffix of the dropdown options when prices
+     * are hidden. `env.showPrice` is set by the product configurator dialog
+     * (false when the website hides all prices); it is only undefined outside
+     * that subtree, where the native behaviour must be preserved.
+     */
+    getPTAVSelectName(ptav) {
+        if (this.env.showPrice === false) {
+            return ptav.name;
+        }
+        return super.getPTAVSelectName(ptav);
+    },
+});

--- a/website_sale_hide_all_prices/static/src/components/product_template_attribute_line.xml
+++ b/website_sale_hide_all_prices/static/src/components/product_template_attribute_line.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <!-- Ocultar los badges de precio extra ("+ $X") de las variantes en el wizard configurador
+         cuando el website oculta todos los precios. env.showPrice lo setea el dialog
+         (false = ocultar); el guard '!== false' preserva el comportamiento nativo donde
+         env.showPrice no está definido (combo dialog, backend). -->
+
+    <t t-name="website_sale_hide_all_prices.ptav_radio"
+       t-inherit="sale.ptav_radio" t-inherit-mode="extension">
+        <xpath expr="//BadgeExtraPrice" position="attributes">
+            <attribute name="t-if">ptav.price_extra and env.showPrice !== false</attribute>
+        </xpath>
+    </t>
+
+    <t t-name="website_sale_hide_all_prices.ptav_pills"
+       t-inherit="sale.ptav_pills" t-inherit-mode="extension">
+        <xpath expr="//BadgeExtraPrice" position="attributes">
+            <attribute name="t-if">ptav.price_extra and env.showPrice !== false</attribute>
+        </xpath>
+    </t>
+
+    <t t-name="website_sale_hide_all_prices.ptav_multi"
+       t-inherit="sale.ptav_multi" t-inherit-mode="extension">
+        <xpath expr="//BadgeExtraPrice" position="attributes">
+            <attribute name="t-if">ptav.price_extra and env.showPrice !== false</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/website_sale_hide_all_prices/views/res_config_settings_views.xml
+++ b/website_sale_hide_all_prices/views/res_config_settings_views.xml
@@ -3,9 +3,9 @@
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.website.sale</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//block[@id='sale_product_catalog_settings']" position="inside">
+            <xpath expr="//setting[@id='hide_add_to_cart_setting']" position="after">
                 <setting id="website_hide_all_prices" string="Hide all prices in my eCommerce" help="All prices on the eCommerce site will be hidden, but customers will be able to add products to the cart in order to request a quote.">
                   <field name="website_hide_all_prices"/>
                 </setting>

--- a/website_sale_hide_all_prices/views/templates.xml
+++ b/website_sale_hide_all_prices/views/templates.xml
@@ -1,66 +1,105 @@
 <odoo>
-   <template id="product_price" inherit_id="website_sale.product_price">
-        <xpath expr="//div[@itemprop='offers']" position="attributes">
+    <!-- product_price: en v19 el div ya no tiene itemprop='offers', usa name='product_price' -->
+    <template id="product_price" inherit_id="website_sale.product_price">
+        <xpath expr="//div[@name='product_price']" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
         </xpath>
     </template>
-   <template id="product" inherit_id="website_sale.product">
-        <xpath expr="//small[@groups='website_sale.group_show_uom_price']" position="attributes">
-            <attribute name="t-if">combination_info['base_unit_price'] or not website.website_hide_all_prices</attribute>
+
+    <!-- product: en v19 el small ya no tiene groups='group_show_uom_price',
+         se identifica por la clase o_base_unit_price_wrapper dentro del bloque de precio -->
+    <template id="product" inherit_id="website_sale.product">
+        <xpath expr="//div[hasclass('o_wsale_product_details_content_section_price')]/small[hasclass('o_base_unit_price_wrapper')]" position="attributes">
+            <attribute name="t-if">combination_info.get('base_unit_price') and not website.website_hide_all_prices</attribute>
         </xpath>
     </template>
+
+    <!-- products_item: en v19 el precio está en div.product_price (no itemprop='offers') -->
     <template id="products_item" inherit_id="website_sale.products_item">
-         <xpath expr="//div[@itemprop='offers']" position="attributes">
+        <xpath expr="//div[hasclass('product_price')]" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
         </xpath>
     </template>
 
+    <!-- suggested_products_list: en v19 el precio está en h6[@name='suggested_product_price_container']
+         (en v18 era div[@name='website_sale_suggested_product_price']) -->
     <template id="suggested_products_list" inherit_id="website_sale.suggested_products_list">
-         <xpath expr="//div[@name='website_sale_suggested_product_price']" position="attributes">
+        <xpath expr="//h6[@name='suggested_product_price_container']" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
         </xpath>
     </template>
 
-    <template id="cart_lines" inherit_id="website_sale.cart_lines">
-         <xpath expr="//div[@name='website_sale_cart_line_price']" position="attributes">
+    <!-- cart_lines_price: en v19 el precio fue extraído a template separado 'cart_lines_price'
+         y el elemento cambió de div a h6 -->
+    <template id="cart_lines_price" inherit_id="website_sale.cart_lines_price">
+        <xpath expr="//h6[@name='website_sale_cart_line_price']" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
         </xpath>
     </template>
 
-     <template id="total" inherit_id="website_sale.total">
-         <xpath expr="//div[@id='cart_total']/table" position="attributes">
-            <attribute name="t-attf-class">#{website.website_hide_all_prices and 'd-none' or ''}</attribute>
+    <!-- total: en v19 ya no existe div[@id='cart_total']; se oculta el bloque completo via t-if -->
+    <template id="total" inherit_id="website_sale.total">
+        <xpath expr="//div[contains(@t-attf-class, 'o_cart_total')]" position="attributes">
+            <attribute name="t-if">not website.website_hide_all_prices and website_sale_order and website_sale_order.website_order_line</attribute>
         </xpath>
     </template>
 
+    <!-- delivery_form: //form[@id='o_delivery_form'] sigue existiendo en v19 -->
     <template id="delivery_form" inherit_id="website_sale.delivery_form">
-         <xpath expr="//form[@id='o_delivery_form']" position="attributes">
+        <xpath expr="//form[@id='o_delivery_form']" position="attributes">
             <attribute name="t-attf-class">#{website.website_hide_all_prices and 'd-none' or ''}</attribute>
         </xpath>
     </template>
 
+    <!-- checkout_layout: amount_total_summary está en checkout_layout -->
     <template id="checkout_layout" inherit_id="website_sale.checkout_layout">
         <xpath expr="//span[@id='amount_total_summary']" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
         </xpath>
+    </template>
+
+    <!-- cart_summary_content: website_sale_cart_summary_line_price está en este sub-template -->
+    <template id="cart_summary_content" inherit_id="website_sale.cart_summary_content">
         <xpath expr="//td[@name='website_sale_cart_summary_line_price']" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
         </xpath>
     </template>
 
-     <template id="navigation_buttons" inherit_id="website_sale.navigation_buttons">
-         <xpath expr="//a[@name='website_sale_main_button']/t" position="attributes">
-            <attribute name="t-if">not website.website_hide_all_prices</attribute>
-        </xpath>
-         <xpath expr="//a[@name='website_sale_main_button']/t" position="after">
-               <t t-if="website.website_hide_all_prices">
+    <!-- navigation_buttons: en el paso de checkout, cuando se ocultan los precios el botón
+         principal deja de apuntar al paso de pago y pasa a confirmar la solicitud de cotización
+         (POST a /shop/request_quotation). Queda siempre habilitado: al no llamarse
+         'website_sale_main_button' no lo toca la lógica de disabled de checkout.js (que exigía un
+         método de envío seleccionado, imposible al ocultar el bloque de envío).
+         Se exige next_website_checkout_step_href truthy para NO reemplazar el botón en
+         /shop/address (ahí vale False y el botón lo usa address.js para guardar la dirección;
+         reemplazarlo salteaba el guardado y volvía al form vacío). -->
+    <template id="navigation_buttons" inherit_id="website_sale.navigation_buttons">
+        <xpath expr="//a[@name='website_sale_main_button']" position="replace">
+            <form t-if="website.website_hide_all_prices and next_website_checkout_step_href"
+                  name="o_wsale_request_quotation"
+                  class="d-flex flex-column"
+                  target="_self"
+                  action="/shop/request_quotation"
+                  method="post">
+                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                <button type="submit" class="btn btn-primary w-100">
                     <span>Request Quotation</span>
-                </t>
+                    <i class="fa fa-angle-right ms-2 fw-light"/>
+                </button>
+            </form>
+            <a t-else=""
+               role="button" name="website_sale_main_button"
+               t-attf-class="btn btn-primary #{not website_sale_order._is_cart_ready() and 'disabled'} w-100"
+               t-att-href="next_website_checkout_step_href">
+                <span t-field="next_website_checkout_step.main_button_label"/>
+                <i class="fa fa-angle-right ms-2 fw-light"/>
+            </a>
         </xpath>
     </template>
 
+    <!-- payment_status: //div[@name='o_payment_status'] sigue existiendo en v19 -->
     <template id="payment_status" inherit_id="payment.payment_status">
-         <xpath expr="//div[@name='o_payment_status']" position="attributes">
+        <xpath expr="//div[@name='o_payment_status']" position="attributes">
             <attribute name="t-attf-class">#{website.website_hide_all_prices and 'd-none' or ''}</attribute>
         </xpath>
     </template>
@@ -81,9 +120,39 @@
          </t>
     </template>
 
+    <!-- badge_extra_price: //span[@t-if='price_extra'] sigue existiendo en v19.
+         Se combina la condición original con la nueva para no perder la lógica de price_extra. -->
     <template id="badge_extra_price" inherit_id="website_sale.badge_extra_price">
-         <xpath expr="//span[@t-if='price_extra']" position="attributes">
+        <xpath expr="//span[@t-if='price_extra']" position="attributes">
+            <attribute name="t-if">price_extra and not website.website_hide_all_prices</attribute>
+        </xpath>
+    </template>
+
+    <!-- Snippet dinámico "Products" (carrousel): el precio se renderiza dentro de
+         div.product_price del template generico del snippet. Se oculta el bloque completo. -->
+    <template id="dynamic_filter_template_product_product_products_item"
+              inherit_id="website_sale.dynamic_filter_template_product_product_products_item">
+        <xpath expr="//div[hasclass('product_price')]" position="attributes">
             <attribute name="t-if">not website.website_hide_all_prices</attribute>
+        </xpath>
+    </template>
+
+    <!-- Comparador - página /shop/compare: dos renders de precio (overview sticky y tabla).
+         Se combina la condición nativa (prevent_zero_price_sale) con website_hide_all_prices. -->
+    <template id="product_compare" inherit_id="website_sale_comparison.product_compare">
+        <xpath expr="//div[@id='miniStickyComparison']//div[hasclass('text-wrap')]" position="attributes">
+            <attribute name="t-if">not combination_info['prevent_zero_price_sale'] and not website.website_hide_all_prices</attribute>
+        </xpath>
+        <xpath expr="//div[@id='o_comparelist_product_name']/span" position="attributes">
+            <attribute name="t-if">not combination_info['prevent_zero_price_sale'] and not website.website_hide_all_prices</attribute>
+        </xpath>
+    </template>
+
+    <!-- Lista de deseos /shop/wishlist: el precio va en un slot product_price propio (o_wish_price),
+         no cubierto por el inherit de products_item. Se oculta via d-none. -->
+    <template id="product_wishlist" inherit_id="website_sale_wishlist.product_wishlist">
+        <xpath expr="//div[hasclass('o_wish_price')]" position="attributes">
+            <attribute name="t-attf-class">align-middle o_wish_price #{website.website_hide_all_prices and 'd-none' or ''}</attribute>
         </xpath>
     </template>
 


### PR DESCRIPTION
## Tarea
https://www.adhoc.inc/odoo/my-tasks/56559

## Resumen
- Actualiza versión a `19.0.1.0.0` y habilita el módulo
- Corrige 7 xpaths rotos en `templates.xml` por cambios estructurales de Odoo 19 en `website_sale`
- Actualiza inserción en `res_config_settings` (bloque `sale_product_catalog_settings` eliminado en v19)
- Reescribe componentes OWL con el patrón `patch()` correcto para Owl 2 (elimina mutación de `this.props` que es readonly)

## Xpaths corregidos

| Template | Problema | Fix |
|---|---|---|
| `product_price` | `itemprop='offers'` eliminado | `name='product_price'` |
| `product` | `groups='group_show_uom_price'` eliminado | `hasclass('o_base_unit_price_wrapper')` |
| `products_item` | `itemprop='offers'` eliminado | `hasclass('product_price')` |
| `suggested_products_list` | `website_sale_suggested_product_price` renombrado | `h6[@name='suggested_product_price_container']` |
| `cart_lines` | precio movido a template `cart_lines_price`, `div` → `h6` | `inherit_id` → `cart_lines_price` |
| `total` | `id='cart_total'` eliminado | `t-if` en `div[contains(@t-attf-class, 'o_cart_total')]` |
| `navigation_buttons` | `<a>` sin hijo `<t>` en v19 | `t-if` en `<a>` + sibling condicional |