### PR TITLE
[FIX] l10n_ar_website_sale_ux: fix AR responsibility field hidden for new customers

### DIFF
--- a/l10n_ar_website_sale_ux/views/portal_address_templates.xml
+++ b/l10n_ar_website_sale_ux/views/portal_address_templates.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Hacemos este parche para evitar KeyError con el usuario de Soporte Adhoc en checkout -->
+    <!--
+        Fix the AR responsibility block to use request.env.company instead of res_company
+        (which may not be in context for all users), and guard responsibility.name against
+        a bool False value (can occur when the partner has no responsibility set).
+    -->
     <template id="address_form_fields_company_fix" inherit_id="portal.address_form_fields">
         <xpath expr="//div[contains(@t-if, 'is_used_as_billing') and contains(@t-if, &quot;res_company.country_id.code == 'AR'&quot;)]" position="attributes">
-            <attribute name="t-if" add="is_used_as_billing and request.env.company.country_code == 'AR' and responsibility" separator="and"/>
+            <attribute name="t-if">is_used_as_billing and request.env.company.country_code == 'AR'</attribute>
+        </xpath>
+        <xpath expr="//p[@t-else=''][@t-out='responsibility.name']" position="attributes">
+            <attribute name="t-out">responsibility and responsibility.name or ''</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
## Problem

When a new customer (no ARCA responsibility type set) reached the billing address step in the website checkout, the ARCA Responsibility field was hidden and could not be filled in. Since the field is mandatory for AR companies, the checkout would fail.

## Root cause

PR #452 added `and responsibility` to the outer `t-if` condition as a workaround for an `AttributeError: 'bool' object has no attribute 'name'` in a client's database. This condition hides the entire div when the partner has no responsibility set (empty recordset = falsy), creating a catch-22: the field is mandatory, but it's hidden so it can never be filled.

Additionally, the `add`/`separator` approach used in #452 kept `res_company.country_id.code == 'AR'` in the evaluated expression, which is the original variable that may not be available in QWeb context for all users (fixed correctly in #450 by switching to `request.env.company`).

## Fix

Two changes in the same template:

1. **Restore the `t-if` replacement approach** (as in #450): set the attribute directly instead of appending, so `res_company` is no longer evaluated and the div is visible for all billing forms in AR companies regardless of whether responsibility is already set.

2. **Guard `responsibility.name` in the read-only branch**: add a safe expression `responsibility and responsibility.name or ''` on the `t-else` paragraph to handle cases where `responsibility` is a bool `False` instead of a recordset.

## Test plan

- New customer with no ARCA responsibility: the responsibility select should be visible at the billing address step and fillable.
- Existing customer with responsibility set: the field displays the current value correctly.
- Existing customer who cannot edit (has issued documents): the read-only paragraph renders without error even if responsibility is unset.