### PR TITLE
[ADD] website_sale_background_post: defer eCommerce invoice posting t…

### DIFF
--- a/website_sale_background_post/__init__.py
+++ b/website_sale_background_post/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models

--- a/website_sale_background_post/__manifest__.py
+++ b/website_sale_background_post/__manifest__.py
@@ -1,0 +1,36 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Website Sale Background Post",
+    "version": "18.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "account_background_post",
+        "website_sale",
+    ],
+    "data": [
+        "views/res_config_settings_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/website_sale_background_post/models/__init__.py
+++ b/website_sale_background_post/models/__init__.py
@@ -1,0 +1,9 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import account_move
+from . import account_move_line
+from . import payment_transaction
+from . import res_company
+from . import res_config_settings

--- a/website_sale_background_post/models/account_move.py
+++ b/website_sale_background_post/models/account_move.py
@@ -1,0 +1,16 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _post(self, soft=True):
+        to_defer = self.env["account.move"]
+        if self.env.context.get("website_force_background_post"):
+            to_defer = self.filtered(lambda m: m.move_type == "out_invoice")
+            to_defer.write({"background_post": True})
+        return super(AccountMove, self - to_defer)._post(soft=soft)

--- a/website_sale_background_post/models/account_move_line.py
+++ b/website_sale_background_post/models/account_move_line.py
@@ -1,0 +1,23 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _check_amls_exigibility_for_reconciliation(self, shadowed_aml_values=None):
+        # When reconciling as part of a background-post flow, the invoice is still
+        # in draft because action_post was deferred. Allow reconciliation with draft
+        # lines — the cron will post the invoice later, at which point the partial
+        # reconcile will still be valid since line amounts are already final.
+        if self.env.context.get("website_force_background_post"):
+            if any(aml.reconciled for aml in self):
+                raise UserError(_("You are trying to reconcile some entries that are already reconciled."))
+            if any(aml.parent_state == "cancel" for aml in self):
+                raise UserError(_("You can only reconcile posted entries."))
+            return
+        return super()._check_amls_exigibility_for_reconciliation(shadowed_aml_values)

--- a/website_sale_background_post/models/payment_transaction.py
+++ b/website_sale_background_post/models/payment_transaction.py
@@ -1,0 +1,38 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, fields, models
+
+
+class PaymentTransaction(models.Model):
+    _inherit = "payment.transaction"
+
+    to_defer = fields.Boolean(
+        string="Defer Invoice Posting",
+        compute="_compute_to_defer",
+        store=True,
+        help="True when this transaction is linked to a website order whose company has "
+        "background invoice posting enabled.",
+    )
+
+    @api.depends("state", "sale_order_ids")
+    def _compute_to_defer(self):
+        for tx in self:
+            tx.to_defer = tx.state == "done" and any(
+                so.website_id and so.company_id.website_sale_background_post for so in tx.sale_order_ids
+            )
+
+    def _post_process(self):
+        deferred = self.filtered("to_defer")
+        if not deferred:
+            return super()._post_process()
+
+        others = self - deferred
+        if others:
+            super(PaymentTransaction, others)._post_process()
+        super(
+            PaymentTransaction,
+            deferred.with_context(website_force_background_post=True),
+        )._post_process()
+        self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()

--- a/website_sale_background_post/models/res_company.py
+++ b/website_sale_background_post/models/res_company.py
@@ -1,0 +1,13 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    website_sale_background_post = fields.Boolean(
+        string="Validate Website Invoices in Background",
+    )

--- a/website_sale_background_post/models/res_config_settings.py
+++ b/website_sale_background_post/models/res_config_settings.py
@@ -1,0 +1,14 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    website_sale_background_post = fields.Boolean(
+        related="company_id.website_sale_background_post",
+        readonly=False,
+    )

--- a/website_sale_background_post/views/res_config_settings_views.xml
+++ b/website_sale_background_post/views/res_config_settings_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.website_sale_background_post</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <block id="website_shop_checkout" position="inside">
+                <setting
+                    id="website_sale_background_post_setting"
+                    string="Validate Website Invoices in Background"
+                    help="When enabled, invoices from eCommerce orders are queued for background validation. Prevents ARCA errors from blocking cart confirmation."
+                    invisible="not automatic_invoice">
+                    <field name="website_sale_background_post"/>
+                </setting>
+            </block>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…o background

New module that prevents ARCA errors from blocking cart confirmation by queueing website sale invoices for background validation instead of posting synchronously.

Depends on account_background_post + website_sale. Key overrides:
- payment.transaction: to_defer computed field + _post_process injects force_background_post context for qualifying transactions
- account.move.action_post: defers out_invoice moves (sets background_post=True), passes payment moves through normally
- account.move.line._check_amls_exigibility_for_reconciliation: allows reconciling draft invoice lines with the payment within the same transaction