### PR TITLE
[IMP] l10n_ar_website_sale_ux: refresh tax-excluded price on variant change

### DIFF
--- a/l10n_ar_website_sale_ux/__manifest__.py
+++ b/l10n_ar_website_sale_ux/__manifest__.py
@@ -20,7 +20,7 @@
 {
     'name': 'l10n_ar Website Sale UX',
     'category': 'base.module_category_knowledge_management',
-    'version': "17.0.1.4.0",
+    'version': "17.0.1.5.0",
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',
@@ -33,6 +33,11 @@
         'views/l10n_ar_website_sale_ux.xml',
         'views/l10n_ar_website_sale_hide_taxes.xml',
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'l10n_ar_website_sale_ux/static/src/js/website_sale.js',
+        ],
+    },
     'installable': True,
     'auto_install': True,
 }

--- a/l10n_ar_website_sale_ux/static/src/js/website_sale.js
+++ b/l10n_ar_website_sale_ux/static/src/js/website_sale.js
@@ -1,0 +1,25 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import "@website_sale/js/website_sale";
+
+/*
+ * RG 4/2025 forces us to show both prices (with and without national taxes) in
+ * the e-commerce. The tax-excluded price is rendered server-side, but it must
+ * also be refreshed when the customer picks another variant on the product
+ * page, mirroring how Odoo updates the regular price on combination change.
+ *
+ * We include the WebsiteSale widget (not the VariantMixin) because the widget
+ * copies the mixin methods into its prototype at definition time, so patching
+ * the mixin afterwards from this asset would never reach the widget instance.
+ */
+publicWidget.registry.WebsiteSale.include({
+    _onChangeCombination(ev, $parent, combination) {
+        this._super.apply(this, arguments);
+        if (combination.price_tax_excluded !== undefined) {
+            $parent.find(".o_l10n_ar_price_tax_excluded .oe_currency_value").text(
+                this._priceToStr(combination.price_tax_excluded, combination.currency_precision)
+            );
+        }
+    },
+});

--- a/l10n_ar_website_sale_ux/views/l10n_ar_website_sale_ux.xml
+++ b/l10n_ar_website_sale_ux/views/l10n_ar_website_sale_ux.xml
@@ -6,7 +6,7 @@
             <span style="white-space: nowrap; font-size:medium; padding-left: 10px" t-if="vat_tax" t-esc="'(+' + vat_tax.name + ')'"  />
         </xpath>
         <xpath expr="//div[1]" >
-            <small t-if="website.company_id.country_code == 'AR' and request.env['website'].browse(website.id).show_line_subtotals_tax_selection == 'tax_included'">Precio Sin Impuestos Nacionales 
+            <small class="o_l10n_ar_price_tax_excluded" t-if="website.company_id.country_code == 'AR' and request.env['website'].browse(website.id).show_line_subtotals_tax_selection == 'tax_included'">Precio Sin Impuestos Nacionales
                     <span t-esc="combination_info['price_tax_excluded']"
                         t-options='{
                            "widget": "monetary",


### PR DESCRIPTION
## What

On the product page, the *Precio Sin Impuestos Nacionales* (RG 4/2025) value is computed server-side in `_get_additionnal_combination_info` and rendered once, but it was **not updated** when the customer selected a different variant — only the regular price refreshed, leaving a stale tax-excluded amount.

## How

- Include the `website_sale` `WebsiteSale` public widget (new `static/src/js/website_sale.js`) and override `_onChangeCombination` to rewrite the tax-excluded amount from `combination.price_tax_excluded` on every combination change, using `_priceToStr` for currency formatting — the same way the core refreshes the regular price. We patch the widget rather than `VariantMixin` because `Widget.extend(VariantMixin, ...)` copies the mixin methods into the prototype at definition time, so a later mixin patch from this asset never reaches the instance.
- Add the `o_l10n_ar_price_tax_excluded` anchor class to the `<small>` wrapper in the `product_price` inherit so the JS can target the inner `.oe_currency_value`.
- Register the asset in `web.assets_frontend` and bump version to 17.0.1.5.0.

No Python changes: the per-combination `price_tax_excluded` was already provided. The JS is guarded so it only acts when the value is present (AR + tax-included websites).

## Test plan

On an AR website with `show_line_subtotals_tax_selection = 'tax_included'`:
1. Open a product with multiple variants having different prices/taxes.
2. Switch variant → both the regular price **and** the *Precio Sin Impuestos Nacionales* should update consistently.

Task: 69616