### PR TITLE
[FIX] website ecommerce tracking: payment blocked by GA4 clobbering advanced_tracking JSON helpers

### DIFF
--- a/facebook_pixel_tracking/static/src/interactions/website_sale_tracking.js
+++ b/facebook_pixel_tracking/static/src/interactions/website_sale_tracking.js
@@ -99,22 +99,30 @@ patch(PaymentForm.prototype, {
 
     // @override
     async submitForm(ev) {
-        const info_div = document.querySelector(".o_website_sale_checkout_container");
-        if (info_div) {
-            const info = JSON.parse(info_div.dataset.purchase_info || '{}');
-            const contents = (info.items || []).map(item => ({
-                id: String(item.item_id),
-                quantity: item.quantity,
-                item_price: item.price,
-            }));
-            const dict = {
-                value: info.value,
-                currency: info.currency,
-                content_ids: contents.map(item => item.id),
-                contents: contents,
-                content_type: 'product',
-            };
-            this._pushInfo('Purchase', dict);
+        // The tracking code must never block the checkout: any failure here
+        // (e.g. malformed data-purchase_info) must not prevent super.submitForm()
+        // from running, since that is where the payment flow and the
+        // stopPropagation/preventDefault on the submit button live.
+        try {
+            const info_div = document.querySelector(".o_website_sale_checkout_container");
+            if (info_div) {
+                const info = JSON.parse(info_div.dataset.purchase_info || '{}');
+                const contents = (info.items || []).map(item => ({
+                    id: String(item.item_id),
+                    quantity: item.quantity,
+                    item_price: item.price,
+                }));
+                const dict = {
+                    value: info.value,
+                    currency: info.currency,
+                    content_ids: contents.map(item => item.id),
+                    contents: contents,
+                    content_type: 'product',
+                };
+                this._pushInfo('Purchase', dict);
+            }
+        } catch (e) {
+            console.error("Facebook Pixel: failed to push Purchase event.", e);
         }
         super.submitForm(...arguments);
     },

--- a/website_sale_google_analytics_4/models/sale_order.py
+++ b/website_sale_google_analytics_4/models/sale_order.py
@@ -32,7 +32,7 @@ class SaleOrder(models.Model):
     # Public helpers used by templates
     # ------------------------------------------------------------------
 
-    def prepare_purchase_information(self):
+    def ga4_purchase_information(self):
         """Return a GA4-compatible purchase dict for this order.
 
         ``transaction_id`` is ``self.id`` (integer) to match the value
@@ -41,6 +41,13 @@ class SaleOrder(models.Model):
 
         Returns an empty dict when called on an empty recordset so that
         QWeb templates can call this method safely in all contexts.
+
+        NOTE: intentionally GA4-namespaced. It must NOT reuse the
+        ``prepare_purchase_information`` name owned by
+        ``website_sale_advanced_tracking`` (which returns a JSON *string*):
+        both modules can be installed side by side and overriding that method
+        with a different return type (dict) breaks the JSON.parse of the
+        facebook_pixel / GTM checkout interactions (task 121712).
         """
         if not self:
             return {}
@@ -48,7 +55,7 @@ class SaleOrder(models.Model):
         delivery_line = self.order_line.filtered("is_delivery")
         # GA4 spec: value = sum(price × qty) for items, shipping and tax separate.
         # Use price_total (tax-inclusive) to stay consistent with the item prices
-        # emitted by prepare_checkout_information() which uses price_reduce_taxinc.
+        # emitted by ga4_checkout_information() which uses price_reduce_taxinc.
         delivery_total = sum(delivery_line.mapped("price_total")) if delivery_line else 0.0
         info = {
             "transaction_id": str(self.id),
@@ -56,7 +63,7 @@ class SaleOrder(models.Model):
             "value": self.amount_total - delivery_total,
             "tax": self.amount_tax,
             "currency": self.currency_id.name,
-            "items": self.order_line.prepare_checkout_information(),
+            "items": self.order_line.ga4_checkout_information(),
         }
         if delivery_line:
             info["shipping"] = delivery_total
@@ -142,7 +149,7 @@ class SaleOrder(models.Model):
         res = super()._action_confirm()
         for order in self:
             try:
-                params = order.prepare_purchase_information()
+                params = order.ga4_purchase_information()
                 order._send_ga4_mp_event("purchase", params)
             except Exception as exc:
                 _logger.warning(

--- a/website_sale_google_analytics_4/models/sale_order_line.py
+++ b/website_sale_google_analytics_4/models/sale_order_line.py
@@ -4,11 +4,18 @@ from odoo import models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    def prepare_checkout_information(self):
+    def ga4_checkout_information(self):
         """Return a GA4-compatible items list for this set of order lines.
 
         Used by QWeb templates to embed cart data as JSON and by
-        prepare_purchase_information() on sale.order.
+        ga4_purchase_information() on sale.order.
+
+        NOTE: intentionally GA4-namespaced. It must NOT reuse the
+        ``prepare_checkout_information`` name owned by
+        ``website_sale_advanced_tracking`` (which returns a JSON *string*):
+        both modules can be installed side by side and overriding that method
+        with a different return type (list) breaks the JSON.parse of the
+        facebook_pixel / GTM checkout interactions (task 121712).
         """
         result = []
         for line in self.filtered(lambda l: not l.is_delivery):

--- a/website_sale_google_analytics_4/views/website_sale_templates.xml
+++ b/website_sale_google_analytics_4/views/website_sale_templates.xml
@@ -13,7 +13,7 @@
             data-order-tracking-info attribute in payment_confirmation_status).
         -->
         <xpath expr="//div[@id='cart_products']" position="attributes">
-            <attribute name="t-att-data-cart-info">json.dumps(website_sale_order.website_order_line.prepare_checkout_information())</attribute>
+            <attribute name="t-att-data-cart-info">json.dumps(website_sale_order.website_order_line.ga4_checkout_information())</attribute>
             <attribute name="t-att-data-currency">website.currency_id.name</attribute>
             <attribute name="t-att-data-value">website_sale_order.amount_total</attribute>
         </xpath>
@@ -43,7 +43,7 @@
     -->
     <template id="checkout_layout_tracking_data" inherit_id="website_sale.checkout_layout">
         <xpath expr="//div[hasclass('o_website_sale_checkout_container')]" position="attributes">
-            <attribute name="t-att-data-purchase-info">website_sale_order.id and json.dumps(website_sale_order.prepare_purchase_information())</attribute>
+            <attribute name="t-att-data-purchase-info">website_sale_order.id and json.dumps(website_sale_order.ga4_purchase_information())</attribute>
         </xpath>
     </template>
 


### PR DESCRIPTION
## Ticket
OBA 121712 — no funciona el pago demo en runbot

## Root cause
`website_sale_google_analytics_4` overrode `sale.order.prepare_purchase_information()`
and `sale.order.line.prepare_checkout_information()` (owned by
`website_sale_advanced_tracking`, return type = JSON string) with a python
dict/list. With both modules installed GA4 wins the MRO, QWeb renders a python
repr (single quotes) into `data-purchase_info`, and `JSON.parse` throws in the
facebook_pixel / GTM `PaymentForm.submitForm` override, blocking
`super.submitForm()`. Result: the pay button does nothing. Latent,
load-order-dependent collision (two sibling modules redefining the same method
with different contracts).

## Fix
- Namespace the GA4 helpers (`ga4_purchase_information` / `ga4_checkout_information`)
  so they stop clobbering the shared contract. No change to advanced_tracking /
  facebook / GTM behaviour.
- Keep the defensive try/catch in `facebook_pixel_tracking.submitForm` as a
  safety net so tracking can never block checkout again.

## Testing
- odoo shell (build 92149-19-0-all): `prepare_purchase_information()` returns a
  JSON string again; `JSON.parse(data-purchase_info)` OK for public and portal
  orders.
- Manual: cart -> checkout -> pay (Demo provider) logged in as portal customer;
  checkout proceeds and AddToCart / InitiateCheckout / Purchase fire in console.
