### PR TITLE
[IMP] website_sale_ux: add eCommerce description toggle on shop tiles

### DIFF
--- a/website_sale_ux/README.rst
+++ b/website_sale_ux/README.rst
@@ -20,6 +20,7 @@ Website Sale UX
 #. Adds a button on the filters sidebar on ecommerce to get back to the shop page unapplying all filters previously set
 #. Makes the native fields description_ecommerce and website_description visible on product.template backend view
 #. Adds a toggle button on website Builder for 'Products list page' customization, called "Prod. Internal. Ref.". This button shows/hides the product internal reference (default_code) on frontend shop views.
+#. Adds a toggle "eCommerce Desc." on the "Products Design" panel of the website Builder, which shows/hides the eCommerce description (description_ecommerce) on the product tiles of the shop, of the wishlist page and of the "Products" dynamic snippet. Natively the shop only offers the quotation description (description_sale), while the product page only shows the eCommerce one, so both can now be shown together, either of them or none. Core's own toggle is renamed from "Description" to "Quotation Desc." to tell them apart. Being an html field, the eCommerce description is clamped to 3 lines on the tile.
 
 Installation
 ============

--- a/website_sale_ux/__manifest__.py
+++ b/website_sale_ux/__manifest__.py
@@ -42,6 +42,9 @@
         "website.website_builder_assets": [
             "website_sale_ux/static/src/website_builder/**/*",
         ],
+        "web.assets_frontend": [
+            "website_sale_ux/static/src/scss/product_tile.scss",
+        ],
     },
     "installable": True,
 }

--- a/website_sale_ux/i18n/es.po
+++ b/website_sale_ux/i18n/es.po
@@ -92,6 +92,12 @@ msgid "Prod. Internal. Ref."
 msgstr "Ref. Interna Prod."
 
 #. module: website_sale_ux
+#. odoo-javascript
+#: code:addons/website_sale_ux/static/src/website_builder/products_design_panel.xml:0
+msgid "Quotation Desc."
+msgstr "Desc. de cotización"
+
+#. module: website_sale_ux
 #: model_terms:ir.ui.view,arch_db:website_sale_ux.website_product_description
 msgid "This note is only displayed in the ecommerce below the product's image."
 msgstr ""
@@ -102,3 +108,9 @@ msgstr ""
 #: model:ir.model,name:website_sale_ux.model_website
 msgid "Website"
 msgstr "Sitio web"
+
+#. module: website_sale_ux
+#. odoo-javascript
+#: code:addons/website_sale_ux/static/src/website_builder/products_design_panel.xml:0
+msgid "eCommerce Desc."
+msgstr "Desc. de eCommerce"

--- a/website_sale_ux/i18n/website_sale_ux.pot
+++ b/website_sale_ux/i18n/website_sale_ux.pot
@@ -83,6 +83,12 @@ msgid "Prod. Internal. Ref."
 msgstr ""
 
 #. module: website_sale_ux
+#. odoo-javascript
+#: code:addons/website_sale_ux/static/src/website_builder/products_design_panel.xml:0
+msgid "Quotation Desc."
+msgstr ""
+
+#. module: website_sale_ux
 #: model_terms:ir.ui.view,arch_db:website_sale_ux.website_product_description
 msgid ""
 "This note is only displayed in the ecommerce below the product's image."
@@ -91,4 +97,10 @@ msgstr ""
 #. module: website_sale_ux
 #: model:ir.model,name:website_sale_ux.model_website
 msgid "Website"
+msgstr ""
+
+#. module: website_sale_ux
+#. odoo-javascript
+#: code:addons/website_sale_ux/static/src/website_builder/products_design_panel.xml:0
+msgid "eCommerce Desc."
 msgstr ""

--- a/website_sale_ux/static/src/scss/product_tile.scss
+++ b/website_sale_ux/static/src/scss/product_tile.scss
@@ -1,0 +1,30 @@
+// Mirrors the mechanism core uses for the quotation description: the block is rendered for
+// website designers and only becomes visible when its design class is on the products grid.
+.o_wsale_ecommerce_description_wrapper {
+    display: var(--o-wsale-card-info-ecommerce-description-display, none);
+}
+
+.o_wsale_products_opt_has_ecommerce_description {
+    --o-wsale-card-info-ecommerce-description-display: block;
+}
+
+// Sizing and spacing reuse core's custom properties, so both descriptions render alike.
+.o_wsale_ecommerce_description {
+    --lines-clamp: 3;
+
+    max-width: 66ch;
+    margin-bottom: var(--o-wsale-card-info-description-margin-bottom, #{map-get($spacers, 2)});
+    font-size: var(--o-wsale-card-info-description-font-size, CLAMP(12px, 0.86em, 0.86rem));
+
+    // `-webkit-line-clamp` counts line boxes, and a replaced element (an image, an embedded
+    // video) is a single one keeping its intrinsic height: capping the block bounds any html.
+    max-height: calc(var(--lines-clamp) * #{$line-height-base} * 1em);
+
+    img, video, iframe, table, .media_iframe_video {
+        max-width: 100%;
+    }
+
+    > :last-child {
+        margin-bottom: 0;
+    }
+}

--- a/website_sale_ux/static/src/website_builder/products_design_panel.xml
+++ b/website_sale_ux/static/src/website_builder/products_design_panel.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website_sale_ux.ProductsDesignPanel" t-inherit="website_sale.ProductsDesignPanel" t-inherit-mode="extension">
+    <!-- Located through the design class the row toggles: unlike the label, it is persisted on
+         "website.shop_opt_products_design_classes" and cannot change without a migration. -->
+    <xpath expr="//BuilderCheckbox[@classAction=&quot;'o_wsale_products_opt_has_description'&quot;]/parent::BuilderRow" position="after">
+        <BuilderRow label.translate="eCommerce Desc.">
+            <BuilderCheckbox classAction="'o_wsale_products_opt_has_ecommerce_description'"/>
+        </BuilderRow>
+    </xpath>
+    <xpath expr="//BuilderCheckbox[@classAction=&quot;'o_wsale_products_opt_has_description'&quot;]/parent::BuilderRow" position="attributes">
+        <attribute name="label.translate">Quotation Desc.</attribute>
+    </xpath>
+</t>
+
+</templates>

--- a/website_sale_ux/views/templates.xml
+++ b/website_sale_ux/views/templates.xml
@@ -7,6 +7,33 @@
             </p>
         </xpath>
     </template>
+    <!-- Anchored on the "t-call" wrapping core's description, not on the wrapper div: "after"
+         the div would nest this block inside that "t-call" and inherit its visibility class. -->
+    <template id="products_item_ecommerce_description" inherit_id="website_sale.products_item" name="Website Products Item eCommerce Description">
+        <xpath expr="//div[hasclass('oe_subdescription_wrapper')]/parent::t" position="after">
+            <t t-call="website_sale.product_tile_element_visibility">
+                <t t-set="visible_element_class" t-value="'o_wsale_products_opt_has_ecommerce_description'"/>
+
+                <div class="o_wsale_ecommerce_description_wrapper">
+                    <div class="o_wsale_ecommerce_description o_line_clamp text-muted" contenteditable="false">
+                        <div t-field="product.description_ecommerce"/>
+                    </div>
+                </div>
+            </t>
+        </xpath>
+    </template>
+    <!-- The panel is shared with the "Products" dynamic snippet, which has its own template:
+         without this the toggle would be a dead switch there. Core renders its own description
+         on it without the editor-only visibility helper, so neither do we. -->
+    <template id="dynamic_products_item_ecommerce_description" inherit_id="website_sale.dynamic_filter_template_product_product_products_item" name="Dynamic Products Item eCommerce Description">
+        <xpath expr="//div[hasclass('oe_subdescription_wrapper')]" position="after">
+            <div class="o_wsale_ecommerce_description_wrapper">
+                <div class="o_wsale_ecommerce_description o_line_clamp text-muted" contenteditable="false">
+                    <div t-field="product.description_ecommerce"/>
+                </div>
+            </div>
+        </xpath>
+    </template>
     <template id="website_internal_ref_product" inherit_id="website_sale.product" name="Website Product Internal Ref" active="False">
         <xpath expr="//div[@id='product_details']" position="inside">
             <p t-if="product.product_variant_count == 1 and product.product_variant_id.default_code" class="text-muted small">


### PR DESCRIPTION
Natively there are two short-description fields and each surface shows a different one: the shop catalogue can only render the quotation description (`description_sale`), while the product page can only render the eCommerce one (`description_ecommerce`). This adds a second toggle so the shop can show either, both, or none.

Task: https://adhoc.inc/odoo/project.task/71445

## What it does

- New design class `o_wsale_products_opt_has_ecommerce_description`, toggled from a new **"eCommerce Desc."** row in the "Products Design" builder panel, right below core's own description row.
- Core's row is relabelled **"Description" → "Quotation Desc."**, since with two description toggles the original label no longer says which field it renders.
- `description_ecommerce` is rendered on `website_sale.products_item` (shop grid and wishlist page) and on `website_sale.dynamic_filter_template_product_product_products_item` (the "Products" dynamic snippet), so the toggle works on every surface whose options embed `ProductsDesignPanel`.
- Spanish translations added: "Desc. de cotización" / "Desc. de eCommerce".

## How

Same mechanism core uses for the quotation description, rather than a separate `websiteConfig` view toggle, so both rows sit together in the panel and keep live preview:

- The block goes through `website_sale.product_tile_element_visibility`, so it stays out of the DOM for regular visitors when the toggle is off, and is rendered (CSS-hidden) for website designers.
- The class is persisted on `website.shop_opt_products_design_classes` like every other design class — no new field, no new config.
- Visibility is driven by a CSS custom property mirroring `--o-wsale-card-info-description-display`.

Unlike `description_sale` (a `Text` field), `description_ecommerce` is `Html` meant for the product page, so on a tile it is clamped to 3 lines with `o_line_clamp` and the block is height-capped: `-webkit-line-clamp` counts line boxes, and a replaced element such as an image or an embedded video is a single line box that keeps its intrinsic height, which would otherwise make that tile much taller than the rest of the grid. Sizing and spacing reuse core's `--o-wsale-card-info-description-*` custom properties so both descriptions render alike and stay tunable per design preset.

The builder panel is inherited by anchoring on the design class the row toggles rather than on its label — the class is persisted in every database and cannot change without a migration, whereas the label is free text.

`version` in the manifest is intentionally not bumped.

## Test plan

On `/shop` with a product carrying both descriptions:

1. Toggle off + quotation on → only `description_sale`.
2. Toggle on + quotation off → only `description_ecommerce`.
3. Both on → both, quotation first.
4. Both off, as an anonymous visitor → neither block is present in the DOM.
5. Toggling the checkbox updates the grid live and, after saving, adds/removes the class in `website.shop_opt_products_design_classes`.
6. A product with a long `description_ecommerce`, or one leading with a large image or an embedded video, stays clamped to 3 lines and does not break the grid — catalog and list layouts, desktop and mobile.
7. Drop a "Products" snippet on a page and enable the toggle in its "Cards Design" panel → the eCommerce description shows on the cards.

## Known trade-offs

- The presets in the "Products Design" panel apply fixed `suggestedClasses` lists and wipe every `o_wsale_products_opt_*` class first, so picking a preset turns this toggle back off (the same is true of any design class core's presets do not list).
- Relabelling core's row means that row falls back to English on databases in languages other than Spanish until the two new terms are translated; both are exported in the `.pot`.
- With the toggle on and `description_ecommerce` empty, edit mode shows no placeholder outline, unlike core's quotation description.
