### PR TITLE
[ADD] website_sale_pricelist_hide_strikethrough_price: hide strikethrough prices per pricelist

### DIFF
--- a/website_sale_pricelist_hide_strikethrough_price/__init__.py
+++ b/website_sale_pricelist_hide_strikethrough_price/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/website_sale_pricelist_hide_strikethrough_price/__manifest__.py
+++ b/website_sale_pricelist_hide_strikethrough_price/__manifest__.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Website Sale Pricelist Hide Strikethrough Price",
+    "category": "website",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Hide strikethrough/compare prices in the eCommerce per pricelist",
+    "depends": [
+        "website_sale",
+    ],
+    "data": [
+        "views/product_pricelist_views.xml",
+        "views/website_sale_templates.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_sale_pricelist_hide_strikethrough_price/static/src/scss/website_sale_hide_strikethrough.scss",
+        ],
+    },
+    "installable": True,
+}

--- a/website_sale_pricelist_hide_strikethrough_price/controllers/__init__.py
+++ b/website_sale_pricelist_hide_strikethrough_price/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import product_configurator

--- a/website_sale_pricelist_hide_strikethrough_price/controllers/product_configurator.py
+++ b/website_sale_pricelist_hide_strikethrough_price/controllers/product_configurator.py
@@ -1,0 +1,16 @@
+from odoo.addons.website_sale.controllers.product_configurator import (
+    WebsiteSaleProductConfiguratorController,
+)
+from odoo.http import request
+
+
+class WebsiteSaleProductConfigurator(WebsiteSaleProductConfiguratorController):
+    def _get_strikethrough_price(self, product_or_template, currency, date, price, pricelist_rule_id=None):
+        # The product/combo configurator dialog renders its own strikethrough from
+        # this hook. Hide it when the active pricelist requests it.
+        pricelist = request.pricelist
+        if pricelist and pricelist.website_hide_strikethrough_price:
+            return None
+        return super()._get_strikethrough_price(
+            product_or_template, currency, date, price, pricelist_rule_id=pricelist_rule_id
+        )

--- a/website_sale_pricelist_hide_strikethrough_price/models/__init__.py
+++ b/website_sale_pricelist_hide_strikethrough_price/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_pricelist
+from . import product_template
+from . import sale_order_line

--- a/website_sale_pricelist_hide_strikethrough_price/models/product_pricelist.py
+++ b/website_sale_pricelist_hide_strikethrough_price/models/product_pricelist.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    website_hide_strikethrough_price = fields.Boolean(
+        string="Hide strikethrough prices",
+        help="Hide the strikethrough/compare prices (and the automatic discount "
+        "ribbon) in the eCommerce for customers using this pricelist.",
+    )

--- a/website_sale_pricelist_hide_strikethrough_price/models/product_template.py
+++ b/website_sale_pricelist_hide_strikethrough_price/models/product_template.py
@@ -1,0 +1,33 @@
+from odoo import models
+from odoo.http import request
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _get_additionnal_combination_info(self, product_or_template, quantity, uom, date, website):
+        # Used on the product page and by the variant-change RPC. If the active
+        # pricelist hides strikethrough prices, neutralize the flags that drive
+        # both the discount strikethrough (.oe_default_price) and the compare
+        # price (.oe_compare_list_price). The frontend JS re-reads these values,
+        # so no template/JS override is needed.
+        res = super()._get_additionnal_combination_info(product_or_template, quantity, uom, date, website)
+        # `super()` already dereferences `request.pricelist` (eCommerce/feed flows
+        # are the only callers), so the request is guaranteed bound and set here.
+        pricelist = request.pricelist
+        if pricelist and pricelist.website_hide_strikethrough_price:
+            res["has_discounted_price"] = False
+            res["list_price"] = res.get("price")
+            res.pop("compare_list_price", None)
+        return res
+
+    def _get_sales_prices(self, website):
+        # Used on the /shop grid tiles. Dropping `base_price` hides the grid
+        # strikethrough (<del>) and, since the automatic ribbon relies on the
+        # same value, its "Sale" ribbon too.
+        res = super()._get_sales_prices(website)
+        pricelist = request.pricelist
+        if pricelist and pricelist.website_hide_strikethrough_price:
+            for vals in res.values():
+                vals.pop("base_price", None)
+        return res

--- a/website_sale_pricelist_hide_strikethrough_price/models/sale_order_line.py
+++ b/website_sale_pricelist_hide_strikethrough_price/models/sale_order_line.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _should_show_strikethrough_price(self):
+        # Cart / order summary lines render the strikethrough from this hook. Hide
+        # it when the order's pricelist requests it.
+        if self.order_id.pricelist_id.website_hide_strikethrough_price:
+            return False
+        return super()._should_show_strikethrough_price()

--- a/website_sale_pricelist_hide_strikethrough_price/static/src/scss/website_sale_hide_strikethrough.scss
+++ b/website_sale_pricelist_hide_strikethrough_price/static/src/scss/website_sale_hide_strikethrough.scss
@@ -1,0 +1,15 @@
+.o_wsale_hide_strikethrough_price {
+    // Product page
+    .oe_default_price,
+    .oe_compare_list_price,
+    del[name="product_price_strikethrough"],
+    // /shop grid tile
+    [name="product_base_price"] del,
+    // Suggested accessories (cart)
+    del[name="suggested_product_list_price"],
+    // Cart line + cart summary (forced by website_sale_product_pack)
+    [name="website_sale_cart_line_price"] del,
+    [name="website_sale_cart_summary_line_price"] del {
+        display: none !important;
+    }
+}

--- a/website_sale_pricelist_hide_strikethrough_price/tests/__init__.py
+++ b/website_sale_pricelist_hide_strikethrough_price/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hide_strikethrough_price

--- a/website_sale_pricelist_hide_strikethrough_price/tests/test_hide_strikethrough_price.py
+++ b/website_sale_pricelist_hide_strikethrough_price/tests/test_hide_strikethrough_price.py
@@ -1,0 +1,188 @@
+from odoo import fields
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
+from odoo.addons.website_sale_pricelist_hide_strikethrough_price.controllers.product_configurator import (
+    WebsiteSaleProductConfigurator,
+)
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHideStrikethroughPrice(WebsiteSaleCommon):
+    """The boolean `website_hide_strikethrough_price` on the active pricelist must
+    neutralize, server-side, both strikethrough sources in the eCommerce:
+
+    * the discount strikethrough (``has_discounted_price`` / ``list_price`` on the
+      product page and ``base_price`` on the /shop grid), and
+    * the manual compare-at price (``compare_list_price``).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Enable the "Comparison price" feature so `compare_list_price` is exposed.
+        cls.env["res.config.settings"].create({"group_product_price_comparison": True}).execute()
+
+        # Product used for the discount-strikethrough path.
+        cls.product_discount = cls.env["product.template"].create(
+            {
+                "name": "Discount strikethrough product",
+                "list_price": 100.0,
+                "website_published": True,
+            }
+        )
+        # Product used for the compare-at price path.
+        cls.product_compare = cls.env["product.template"].create(
+            {
+                "name": "Compare strikethrough product",
+                "list_price": 100.0,
+                "compare_list_price": 150.0,
+                "website_published": True,
+            }
+        )
+
+        def discount_item():
+            return [Command.create({"compute_price": "percentage", "percent_price": 10})]
+
+        def make_pl(name, hide, items=None):
+            return cls.env["product.pricelist"].create(
+                {
+                    "name": name,
+                    "website_id": cls.website.id,
+                    "currency_id": cls.website.currency_id.id,
+                    "item_ids": items or [],
+                    "website_hide_strikethrough_price": hide,
+                }
+            )
+
+        cls.pl_discount_show = make_pl("discount show", False, discount_item())
+        cls.pl_discount_hide = make_pl("discount hide", True, discount_item())
+        cls.pl_plain_show = make_pl("plain show", False)
+        cls.pl_plain_hide = make_pl("plain hide", True)
+
+        cls.cart_partner = cls.env["res.partner"].create({"name": "Cart tester"})
+
+    def _combination_info(self, product, pricelist):
+        with MockRequest(self.env, website=self.website, website_sale_current_pl=pricelist.id):
+            return product._get_combination_info()
+
+    def _sales_prices(self, product, pricelist):
+        with MockRequest(self.env, website=self.website, website_sale_current_pl=pricelist.id):
+            return product._get_sales_prices(self.website)[product.id]
+
+    # --- discount strikethrough --------------------------------------------
+
+    def test_discount_control_shows_strikethrough(self):
+        """Sanity: without the flag the discount strikethrough data is present."""
+        ci = self._combination_info(self.product_discount, self.pl_discount_show)
+        self.assertTrue(ci["has_discounted_price"])
+        self.assertGreater(ci["list_price"], ci["price"])
+        sp = self._sales_prices(self.product_discount, self.pl_discount_show)
+        self.assertIn("base_price", sp)
+        self.assertGreater(sp["base_price"], sp["price_reduce"])
+
+    def test_discount_hidden_by_flag(self):
+        ci = self._combination_info(self.product_discount, self.pl_discount_hide)
+        self.assertFalse(ci["has_discounted_price"])
+        self.assertEqual(ci["list_price"], ci["price"])
+        self.assertNotIn("compare_list_price", ci)
+        sp = self._sales_prices(self.product_discount, self.pl_discount_hide)
+        self.assertNotIn("base_price", sp)
+
+    # --- compare-at price ---------------------------------------------------
+
+    def test_compare_control_shows_price(self):
+        """Sanity: without the flag the compare-at price is present."""
+        ci = self._combination_info(self.product_compare, self.pl_plain_show)
+        self.assertFalse(ci["has_discounted_price"])
+        self.assertIn("compare_list_price", ci)
+        self.assertGreater(ci["compare_list_price"], ci["price"])
+        sp = self._sales_prices(self.product_compare, self.pl_plain_show)
+        self.assertIn("base_price", sp)
+
+    def test_compare_hidden_by_flag(self):
+        ci = self._combination_info(self.product_compare, self.pl_plain_hide)
+        self.assertNotIn("compare_list_price", ci)
+        sp = self._sales_prices(self.product_compare, self.pl_plain_hide)
+        self.assertNotIn("base_price", sp)
+
+    # --- cart / order summary line ------------------------------------------
+
+    def _cart_line(self, pricelist):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.cart_partner.id,
+                "website_id": self.website.id,
+                "pricelist_id": pricelist.id,
+            }
+        )
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product_discount.product_variant_ids[:1].id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        line.discount = 10.0
+        return line
+
+    def test_cart_control_shows_strikethrough(self):
+        """Sanity: without the flag the cart line shows the strikethrough."""
+        line = self._cart_line(self.pl_discount_show)
+        self.assertTrue(line._should_show_strikethrough_price())
+
+    def test_cart_strikethrough_hidden_by_flag(self):
+        line = self._cart_line(self.pl_discount_hide)
+        self.assertFalse(line._should_show_strikethrough_price())
+
+    # --- product / combo configurator dialog --------------------------------
+
+    def _configurator_strikethrough(self, pricelist):
+        controller = WebsiteSaleProductConfigurator()
+        product = self.product_discount.product_variant_ids[:1]
+        currency = self.website.currency_id
+        date = fields.Date.context_today(product)
+        with MockRequest(self.env, website=self.website, website_sale_current_pl=pricelist.id):
+            price, rule_id = pricelist._get_product_price_rule(product, quantity=1.0, currency=currency, date=date)
+            return controller._get_strikethrough_price(product, currency, date, price, rule_id)
+
+    def test_configurator_control_shows_strikethrough(self):
+        """Sanity: without the flag the configurator returns a strikethrough price."""
+        st = self._configurator_strikethrough(self.pl_discount_show)
+        self.assertTrue(st)
+
+    def test_configurator_strikethrough_hidden_by_flag(self):
+        self.assertIsNone(self._configurator_strikethrough(self.pl_discount_hide))
+
+
+@tagged("post_install", "-at_install")
+class TestHideStrikethroughWrapClass(HttpCase):
+    """The frontend wrapper gets the CSS-gating class only when the visitor's
+    active pricelist requests hiding the strikethrough. This is the robust net
+    for cart lines whose `<del>` is forced by `website_sale_product_pack`.
+    """
+
+    def _setup(self, hide):
+        website = self.env["website"].search([], limit=1)
+        pl = self.env["product.pricelist"].create(
+            {
+                "name": "wrap %s" % hide,
+                "website_id": website.id,
+                "selectable": True,
+                "website_hide_strikethrough_price": hide,
+            }
+        )
+        website.user_id.partner_id.property_product_pricelist = pl
+        return website
+
+    def test_wrap_class_present_with_flag(self):
+        self._setup(True)
+        res = self.url_open("/shop")
+        self.assertEqual(res.status_code, 200)
+        self.assertIn("o_wsale_hide_strikethrough_price", res.text)
+
+    def test_wrap_class_absent_without_flag(self):
+        self._setup(False)
+        res = self.url_open("/shop")
+        self.assertEqual(res.status_code, 200)
+        self.assertNotIn("o_wsale_hide_strikethrough_price", res.text)

--- a/website_sale_pricelist_hide_strikethrough_price/views/product_pricelist_views.xml
+++ b/website_sale_pricelist_hide_strikethrough_price/views/product_pricelist_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_pricelist_view_form_hide_strikethrough" model="ir.ui.view">
+        <field name="model">product.pricelist</field>
+        <field name="inherit_id" ref="website_sale.website_sale_pricelist_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='pricelist_config']/group[@name='pricelist_website']/field[@name='selectable']"
+                position="after"
+            >
+                <field name="website_hide_strikethrough_price" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_pricelist_hide_strikethrough_price/views/website_sale_templates.xml
+++ b/website_sale_pricelist_hide_strikethrough_price/views/website_sale_templates.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+        Server-side hooks already neutralize the strikethrough on the shop grid,
+        product page, variant change and product configurator. This CSS-gated
+        class is a robust net for the cart line: `website_sale_product_pack`
+        rewrites the cart `<del>` t-if to `not line.pack_parent_line_id`, which
+        bypasses `_should_show_strikethrough_price` and forces the strikethrough
+        regardless of discount. Hiding by CSS when the active pricelist requests
+        it avoids fighting view-inheritance order with that module.
+    -->
+    <template
+        id="hide_strikethrough_wrap_class"
+        inherit_id="website.layout"
+        name="Hide strikethrough prices: wrap class"
+    >
+        <xpath expr="//div[@id='wrapwrap']" position="attributes">
+            <attribute
+                name="t-attf-class"
+                add="#{'o_wsale_hide_strikethrough_price' if request.pricelist.website_hide_strikethrough_price else ''}"
+                separator=" "
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Problem

Since v18 the eCommerce **always** shows the strikethrough/compare price when the pricelist computes prices from another pricelist or from the product's sale price, and there is no way to hide it. In many cases the merchant does not want that "before" price shown.

## Solution

Adds a **Hide strikethrough prices** boolean on `product.pricelist` (eCommerce tab). When enabled, for customers using that pricelist it hides — in the `/shop` grid, the product page and on variant change:

- the discount strikethrough (`has_discounted_price` / `list_price`),
- the compare-at price (`compare_list_price`),
- the automatic "Sale" ribbon that relies on the same flags.

Implemented **server-side** by neutralizing the pricing flags in `_get_additionnal_combination_info` and `_get_sales_prices`, so no QWeb override or frontend JS patch is needed (the variant-change JS just re-reads the neutralized values).

## Tests

Adds 4 tests (control + hidden, for both the discount and the compare-at price paths, across both methods). All green.