### PR TITLE
[FIX] website_sale_background_post: follow background_post rename to a scheduling date

### DIFF
--- a/website_sale_background_post/models/account_move.py
+++ b/website_sale_background_post/models/account_move.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import fields, models
 
 
 class AccountMove(models.Model):
@@ -12,5 +12,6 @@ class AccountMove(models.Model):
         to_defer = self.env["account.move"]
         if self.env.context.get("website_force_background_post"):
             to_defer = self.filtered(lambda m: m.move_type == "out_invoice")
-            to_defer.write({"background_post": True})
+            # Post as soon as the cron runs, the order is already paid
+            to_defer.write({"background_post_date": fields.Datetime.now()})
         return super(AccountMove, self - to_defer)._post(soft=soft)


### PR DESCRIPTION
## What

`website_sale_background_post` defers the posting of a paid website order's invoice by writing the `background_post` flag.

ingadhoc/account-invoicing#312 replaces that boolean with the `background_post_date` datetime, so the write raises a `ValueError` on an unknown field once both are installed — this module depends on `account_background_post`.

## Changes

- `write({"background_post": True})` → `write({"background_post_date": fields.Datetime.now()})`.

Scheduling for the current moment keeps the previous behaviour: the order is already paid, so the invoice should be posted on the next cron run. `_post_process` already triggers that cron right after deferring, so nothing else changes.

## Test plan

Same runbot batch as the PR that renames the field (same branch name). This module has no tests and is not installed in the OBA build, so it was found by grepping the org for the old field name rather than by a failing build — which is precisely why it is worth fixing in the same batch.

Task: https://www.adhoc.inc/mail/view?model=project.task&res_id=72206
