### PR TITLE
[IMP] website_sale_ux: allow restricting checkout countries

### DIFF
--- a/website_sale_ux/README.rst
+++ b/website_sale_ux/README.rst
@@ -20,6 +20,7 @@ Website Sale UX
 #. Adds a button on the filters sidebar on ecommerce to get back to the shop page unapplying all filters previously set
 #. Makes the native fields description_ecommerce and website_description visible on product.template backend view
 #. A toggle button is added on website Builder for 'Product page' cutomization, called "Sale description". This button shows/hides the sale_description field on frontend view.
+#. Adds a "Checkout Countries" option on website settings to restrict the countries available on the eCommerce checkout address form. When the visitor's geolocated country is not allowed, the form defaults to the website company's country instead of the geolocation.
 
 Installation
 ============

--- a/website_sale_ux/controllers/main.py
+++ b/website_sale_ux/controllers/main.py
@@ -10,6 +10,35 @@ class WebsiteSale(main.WebsiteSale):
         payment_values["submit_button_label"] = _("Complete Purchase")
         return payment_values
 
+    def _prepare_address_form_values(self, order_sudo, partner_sudo, address_type, **kwargs):
+        rendering_values = super()._prepare_address_form_values(
+            order_sudo, partner_sudo, address_type=address_type, **kwargs
+        )
+        website = http.request.website.sudo()
+        allowed_countries = website.checkout_country_ids
+        if not allowed_countries:
+            return rendering_values
+
+        rendering_values["countries"] = allowed_countries
+        country = rendering_values.get("country")
+        if country not in allowed_countries:
+            # The standard default (GeoIP, with the public user's country as fallback) is
+            # not reliable when the shop sells to a restricted set of countries: behind a
+            # proxy the geolocated country can be plain wrong for every visitor.
+            company_country = website.company_id.country_id
+            country = company_country if company_country in allowed_countries else allowed_countries[0]
+            address_fields = country.get_address_fields()
+            rendering_values.update(
+                {
+                    "country": country,
+                    "country_states": country.state_ids,
+                    "zip_before_city": (
+                        "zip" in address_fields and address_fields.index("zip") < address_fields.index("city")
+                    ),
+                }
+            )
+        return rendering_values
+
 
 class WebsiteBinary(Binary):
     @http.route()

--- a/website_sale_ux/i18n/es.po
+++ b/website_sale_ux/i18n/es.po
@@ -31,6 +31,13 @@ msgid "Complete Purchase"
 msgstr "Finalizar compra"
 
 #. module: website_sale_ux
+#: model:ir.model.fields,field_description:website_sale_ux.field_res_config_settings__checkout_country_ids
+#: model:ir.model.fields,field_description:website_sale_ux.field_website__checkout_country_ids
+#: model_terms:ir.ui.view,arch_db:website_sale_ux.res_config_settings_view_form
+msgid "Checkout Countries"
+msgstr "Países del checkout"
+
+#. module: website_sale_ux
 #: model:ir.model,name:website_sale_ux.model_res_config_settings
 msgid "Config Settings"
 msgstr "Ajustes de configuración"
@@ -61,6 +68,33 @@ msgid ""
 msgstr ""
 "Esta nota solo se mostrará debajo de la imagen en la \"Página de producto\" "
 "del eCommerce."
+
+#. module: website_sale_ux
+#: model:ir.model.fields,help:website_sale_ux.field_res_config_settings__checkout_country_ids
+#: model:ir.model.fields,help:website_sale_ux.field_website__checkout_country_ids
+msgid ""
+"Restrict the countries offered in the eCommerce checkout address form to "
+"this list. When the visitor's geolocated country is not in the list, the "
+"form defaults to the website company's country (or to the first country of "
+"the list). Leave empty to keep the standard behavior (all countries, "
+"default by geolocation)."
+msgstr ""
+"Limita los países ofrecidos en el formulario de dirección del checkout del "
+"eCommerce a esta lista. Cuando el país geolocalizado del visitante no está "
+"en la lista, el formulario propone por defecto el país de la compañía del "
+"sitio web (o el primer país de la lista). Dejar vacío para mantener el "
+"comportamiento estándar (todos los países, default por geolocalización)."
+
+#. module: website_sale_ux
+#: model_terms:ir.ui.view,arch_db:website_sale_ux.res_config_settings_view_form
+msgid ""
+"Restrict the countries available in the checkout address form. If the "
+"visitor's geolocated country is not allowed, the form defaults to the "
+"company country instead."
+msgstr ""
+"Limita los países disponibles en el formulario de dirección del checkout. "
+"Si el país geolocalizado del visitante no está permitido, el formulario "
+"propone por defecto el país de la compañía."
 
 #. module: website_sale_ux
 #: model_terms:ir.ui.view,arch_db:website_sale_ux.products

--- a/website_sale_ux/models/res_config_settings.py
+++ b/website_sale_ux/models/res_config_settings.py
@@ -9,6 +9,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     disable_categories_search = fields.Boolean(related="website_id.disable_categories_search", readonly=False)
+    checkout_country_ids = fields.Many2many(related="website_id.checkout_country_ids", readonly=False)
 
     @api.model
     def _inverse_account_on_checkout(self):

--- a/website_sale_ux/models/website.py
+++ b/website_sale_ux/models/website.py
@@ -9,6 +9,14 @@ class Website(models.Model):
     _inherit = "website"
 
     disable_categories_search = fields.Boolean()
+    checkout_country_ids = fields.Many2many(
+        "res.country",
+        string="Checkout Countries",
+        help="Restrict the countries offered in the eCommerce checkout address form to this list. "
+        "When the visitor's geolocated country is not in the list, the form defaults to the "
+        "website company's country (or to the first country of the list). "
+        "Leave empty to keep the standard behavior (all countries, default by geolocation).",
+    )
 
     def _search_get_details(self, search_type, order, options):
         res = super(Website, self)._search_get_details(search_type, order, options)

--- a/website_sale_ux/views/res_config_settings_views.xml
+++ b/website_sale_ux/views/res_config_settings_views.xml
@@ -10,6 +10,11 @@
                     <field name="disable_categories_search"/>
                 </setting>
             </block>
+            <block id="website_shop_checkout" position="inside">
+                <setting id="checkout_countries_setting" string="Checkout Countries" help="Restrict the countries available in the checkout address form. If the visitor's geolocated country is not allowed, the form defaults to the company country instead.">
+                    <field name="checkout_country_ids" widget="many2many_tags"/>
+                </setting>
+            </block>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Problema

El formulario de dirección del checkout de `website_sale` (v18) resuelve el país por defecto así (`_prepare_address_form_values`, `website_sale/controllers/main.py` ~L1177):

1. País del partner (si el visitante ya tiene dirección).
2. Si no hay: **GeoIP** de la request (`request.geoip.country_code`).
3. Si GeoIP no resuelve: país del usuario público del website (default de Odoo: Antártida).

Además, el selector de países lista **todos** los países (`res.country.search([])`) — no hay ninguna configuración nativa para restringirlo ni para forzar un default.

Para una tienda que vende a un solo país esto es un problema real: si la geolocalización viene mal (p. ej. detrás de un proxy que no forwardea la IP real del cliente, o visitantes con VPN), a **todos** los visitantes se les preselecciona un país extranjero — con el listado de provincias/departamentos de ese país y el prefijo telefónico equivocado en el placeholder — y el comprador que no lo advierte no puede completar la compra. Caso concreto: base uruguaya (compañía UY, sin ningún módulo AR instalado) cuyo checkout abre con "Argentina / Buenos Aires / +54" para visitantes uruguayos; el cliente reporta pérdida de ventas (ticket 125508).

## Solución propuesta

Nueva opción **"Checkout Countries"** (m2m `res.country` en `website`, expuesta en Ajustes de Sitio Web → sección *Shop - Checkout Process*). Cuando está seteada:

- El selector de países del formulario de dirección ofrece **solo esos países**.
- Si el país geolocalizado no está en la lista, el default pasa a ser el **país de la compañía del website** (o el primer país de la lista si la compañía tampoco está). Se recalculan `country_states` y `zip_before_city` en consecuencia.

Vacía (default), el comportamiento estándar no cambia en nada.

Se implementa como override de `_prepare_address_form_values` en `website_sale_ux`, componible con los overrides de las localizaciones (`l10n_uy_website_sale`, `l10n_ar_website_sale`, etc., que solo tocan campos de identificación y no el país).

## Test plan

- `pre-commit run` sobre los archivos tocados: OK (ruff, pylint-odoo, rstcheck, check-po).
- Instalación desde cero en DB 18.0 local (`-i website_sale_ux --stop-after-init`): OK, campo `checkout_country_ids` creado (`res_country_website_rel`).
- Pendiente validación funcional por el equipo de website: checkout anónimo con la opción seteada (país default y selector restringido) y sin setear (sin cambios de comportamiento). No se agregaron tests automatizados del controller — si el approach cierra, puedo sumar un `HttpCase`.

## Notas

- El mismo síntoma incluye la validación de CI/NIE de `l10n_uy` con un mensaje de error confuso; eso va por separado como PR a `odoo/odoo` (mensaje `expected_format` de `l10n_uy/models/res_partner.py`).
- Relacionado al ticket interno 125508.