### PR TITLE
[FIX] l10n_ar_website_sale_ux: price without national taxes on product page

### DIFF
--- a/l10n_ar_website_sale_ux/__init__.py
+++ b/l10n_ar_website_sale_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_website_sale_ux/models/__init__.py
+++ b/l10n_ar_website_sale_ux/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/l10n_ar_website_sale_ux/models/product_template.py
+++ b/l10n_ar_website_sale_ux/models/product_template.py
@@ -1,0 +1,39 @@
+from odoo import models
+from odoo.http import request
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _get_additionnal_combination_info(self, product_or_template, quantity, uom, date, website):
+        """Corregimos el precio sin impuestos nacionales de la ficha de producto.
+
+        `l10n_ar_website_sale` lo calcula sobre el precio de la lista de precios
+        (que ya viene con el descuento aplicado) y despues le vuelve a restar
+        ese mismo descuento, con lo cual el valor queda por debajo del real. Lo
+        recalculamos sin ese ajuste, igual que en la pagina de la tienda.
+        """
+        combination_info = super()._get_additionnal_combination_info(product_or_template, quantity, uom, date, website)
+
+        if "l10n_ar_price_tax_excluded" not in combination_info:
+            return combination_info
+
+        currency = combination_info["currency"]
+        pricelist_price, _rule_id = request.pricelist._get_product_price_rule(
+            product=product_or_template,
+            quantity=quantity,
+            uom=uom,
+            currency=currency,
+        )
+        # Misma adaptacion de base imponible que hace `website_sale` antes de aplicar
+        # los impuestos, para el caso de un impuesto incluido remapeado por posicion fiscal.
+        pricelist_price = self.env["product.product"]._get_tax_included_unit_price_from_price(
+            pricelist_price,
+            combination_info["product_taxes"],
+            product_taxes_after_fp=combination_info["taxes"],
+        )
+        combination_info["l10n_ar_price_tax_excluded"] = combination_info["taxes"].compute_all(
+            pricelist_price, currency, 1, product_or_template, self.env.user.partner_id
+        )["total_excluded"]
+
+        return combination_info


### PR DESCRIPTION
## Problema

En el eCommerce, la leyenda "Precio s/Imp. Nac." de la **ficha de producto** muestra un importe menor al real cuando el producto tiene descuento por lista de precios. El **listado de la tienda** muestra el valor correcto, así que las dos páginas se contradicen.

Caso real (descuento 23%, IVA 21%):

| Vista | Precio | Precio s/Imp. Nac. |
|---|---|---|
| Shop | $41.648,85 | $34.420,54 ✅ |
| Ficha de producto | $41.648,85 | $26.503,81 ❌ (= 34.420,54 × 0,77) |

## Causa

En `l10n_ar_website_sale/models/product_template.py`, `_get_additionnal_combination_info` calcula `l10n_ar_price_tax_excluded` sobre el precio que devuelve `pricelist._compute_price_rule(...)` — que **ya tiene el descuento aplicado** — y después vuelve a restarle el mismo descuento:

```python
if combination_info['has_discounted_price']:
    discount_percent = (combination_info['list_price'] - combination_info['price']) / combination_info['list_price']
    total_excluded_value = total_excluded_value * (1 - discount_percent)
```

`_get_sales_prices` (el listado de la tienda) hace el mismo cálculo **sin** ese ajuste, y por eso da bien.

## Solución

Override de `_get_additionnal_combination_info` en `l10n_ar_website_sale_ux` que recalcula el valor sin ese ajuste, siguiendo el mismo camino que `website_sale._apply_taxes_to_price` (misma adaptación de base imponible vía `_get_tax_included_unit_price_from_price` y mismo `compute_all`), sólo que quedándose con `total_excluded`. Reusa `currency`, `product_taxes` y `taxes` que el módulo estándar ya publica en `combination_info`, y le pide el precio a la lista con la `uom` y la moneda del pedido.

Es un fix sobre el módulo estándar; corresponde también reportarlo upstream para removerlo de acá cuando se corrija.

## Verificación

Probado sobre una base 19 con una lista de precios de 23% de descuento global y un producto de 1000 con IVA 21%: el precio sin impuestos nacionales pasa de 592,90 (mal, 770 × 0,77) a 770,00 (correcto), y el precio mostrado sigue siendo 931,70.

Los 4 tests de `l10n_ar_website_sale` siguen pasando con el módulo instalado (es `auto_install`, así que el override está activo).

Sin migration script → `nobump`.
