### PR TITLE
[ADD] website_sale_express_checkout: one-page AR checkout

### DIFF
--- a/website_sale_express_checkout/README.rst
+++ b/website_sale_express_checkout/README.rst
@@ -1,0 +1,119 @@
+==================================
+Website Sale Express Checkout AR
+==================================
+
+Checkout de una sola página para el eCommerce argentino, con derivación de los
+datos tributarios del lado del servidor.
+
+Características
+===============
+
+- Colapsa el checkout del eCommerce en un único paso (``cart`` →
+  ``express_checkout`` → ``payment``), despublicando los pasos nativos de
+  dirección y de información extra.
+- Se activa solo cuando la company del carrito tiene ``country_code == 'AR'`` y
+  el website tiene habilitado el express checkout; en cualquier otro caso rige
+  el flujo nativo de cuatro pasos, sin alteración.
+- El comprador no toma ninguna decisión tributaria: la Responsabilidad ARCA y el
+  tipo de documento se derivan del lado del servidor.
+- Los campos tributarios derivados no se renderizan en ninguna forma y se
+  descartan del payload entrante, por lo que un POST forjado no puede fijarlos.
+- Sección "Factura A" que pide únicamente el CUIT; el resto de la información
+  fiscal la resuelve el servidor (y el padrón de ARCA a través del bridge).
+- El domicilio ``street2`` se ofrece detrás de un disclosure colapsado.
+- Al habilitar el express checkout se fuerza la validación de facturas en
+  background para la company.
+
+Detalles Técnicos
+=================
+
+Modelos heredados
+-----------------
+
+- ``website``: campo ``enable_express_checkout``; override de
+  ``_create_checkout_steps`` y ``write`` que sincronizan la publicación de los
+  pasos por website mediante ``_sync_express_checkout_steps``; al habilitar se
+  setea ``res.company.website_sale_background_post``.
+- ``res.config.settings``: campo ``enable_express_checkout`` relacionado con el
+  website.
+
+Controlador
+-----------
+
+``WebsiteSaleExpressCheckout(WebsiteSale)``:
+
+- ``GET /shop/express_checkout`` — render de la página única.
+- ``POST /shop/express_checkout/submit`` — submit único; delega la creación del
+  partner en ``_create_or_update_address`` (no la reimplementa) y arma el reparto
+  de direcciones (Consumidor Final vs. Factura A).
+- Overrides de ``_parse_form_data``, ``_get_mandatory_billing_address_fields`` y
+  ``_complete_address_values``, acotados al flujo express vía
+  ``request.express_checkout_flow``.
+- Hook ``_express_apply_padron`` (no-op; lo implementa el bridge del padrón).
+
+Datos
+-----
+
+- ``website.checkout.step`` genérico ``express_checkout`` (``step_href =
+  /shop/express_checkout``).
+
+Vistas
+------
+
+- ``res.config.settings`` — setting "Express Checkout (AR)".
+- ``address_form_fields`` — view primario que hereda
+  ``portal.address_form_fields``.
+- ``express_checkout`` — página del checkout de una sola página.
+
+Assets
+------
+
+- Interaction de frontend que extiende ``portal.customer_address`` (toggle de
+  Factura A y validación del CUIT en vivo).
+
+Hooks
+-----
+
+- ``post_init_hook`` — propaga el paso ``express_checkout`` a los websites
+  existentes y sincroniza la publicación.
+- ``uninstall_hook`` — elimina el paso express por website y republica los pasos
+  nativos.
+
+Uso
+===
+
+1. Instalar el módulo.
+2. En Ajustes → Sitio web → eCommerce, activar "Express Checkout (AR)" en el
+   website argentino. Esto reconfigura los pasos del checkout y habilita la
+   validación de facturas en background de la company.
+3. El comprador de la tienda completa la compra en una sola página con los datos
+   mínimos; si necesita Factura A marca la casilla e ingresa su CUIT.
+
+Arquitectura
+============
+
+El módulo reusa los métodos-hook nativos de ``portal`` / ``website_sale`` en
+lugar de forkear controladores o templates: el submit pasa por
+``_create_or_update_address`` (heredando las extensiones de las localizaciones) y
+el template es un view primario que hereda ``portal.address_form_fields`` (por lo
+que ``_get_combined_archs`` le aplica las contribuciones de los módulos de
+localización). La reconfiguración del checkout se hace de forma declarativa sobre
+``website.checkout.step`` (publicación por website), sin overrides del motor de
+navegación.
+
+Dependencias
+============
+
+- ``website_sale``
+- ``l10n_ar_website_sale``
+- ``website_sale_background_post``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/website_sale_express_checkout/__init__.py
+++ b/website_sale_express_checkout/__init__.py
@@ -1,0 +1,7 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models
+from . import controllers
+from .hooks import post_init_hook, uninstall_hook

--- a/website_sale_express_checkout/__manifest__.py
+++ b/website_sale_express_checkout/__manifest__.py
@@ -1,0 +1,48 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Website Sale Express Checkout AR",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "category": "Website/Website",
+    "summary": "One-page checkout for Argentinean eCommerce, with server-side tax derivation",
+    "depends": [
+        "website_sale",
+        "l10n_ar_website_sale",
+        "website_sale_background_post",
+    ],
+    "data": [
+        "data/website_checkout_step_data.xml",
+        "views/res_config_settings_views.xml",
+        "views/express_checkout_templates.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_sale_express_checkout/static/src/interactions/express_checkout.js",
+        ],
+    },
+    "post_init_hook": "post_init_hook",
+    "uninstall_hook": "uninstall_hook",
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/website_sale_express_checkout/controllers/__init__.py
+++ b/website_sale_express_checkout/controllers/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import main

--- a/website_sale_express_checkout/controllers/main.py
+++ b/website_sale_express_checkout/controllers/main.py
@@ -1,0 +1,544 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import json
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.http import request, route
+from odoo.tools import str2bool
+
+# Address fields the buyer fills; everything else in the payload is contact/tax.
+_ADDRESS_FIELDS = ("street", "street2", "city", "zip", "state_id")
+# Contact fields persisted (together with the address and CF document) on the
+# provisional partner so the form survives navigating away and back.
+_EXPRESS_CONTACT_FIELDS = ("name", "email", "phone")
+
+
+class WebsiteSaleExpressCheckout(WebsiteSale):
+    """One-page AR checkout.
+
+    NOTE ON ROUTE COEXISTENCE: core already defines ``/shop/express_checkout`` as
+    ``type='jsonrpc', methods=['POST']`` (Google/Apple Pay express flow,
+    ``WebsiteSale.process_express_checkout``). Our render route below is
+    ``type='http'`` GET, so both rules coexist in the routing map (matched by
+    method) and the buyer-facing submit lives at ``/shop/express_checkout/submit``.
+
+    The ``_parse_form_data`` / ``_complete_address_values`` /
+    ``_get_mandatory_billing_address_fields`` overrides are merged into the global
+    ``WebsiteSale`` controller, so they must be scoped to the express flow via the
+    ``request.express_checkout_flow`` flag (set by the submit route). Outside that
+    flow they defer entirely to super().
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _express_checkout_enabled(self, order_sudo):
+        """The express flow is AR-only and opt-in per website (checked on the
+        cart's company, not the user's — matches personalizations_adhoc)."""
+        return bool(
+            order_sudo and order_sudo.website_id.enable_express_checkout and order_sudo.company_id.country_code == "AR"
+        )
+
+    # ------------------------------------------------------------------
+    # Render
+    # ------------------------------------------------------------------
+    @route(
+        "/shop/express_checkout",
+        type="http",
+        auth="public",
+        website=True,
+        sitemap=False,
+    )
+    def express_checkout(self, **query_params):
+        order_sudo = request.cart
+        if redirection := self._check_cart(order_sudo):
+            return request.redirect(redirection.location)
+        if not self._express_checkout_enabled(order_sudo):
+            # Module installed but disabled / non-AR company: fall back to native.
+            return request.redirect("/shop/checkout")
+        render_values = self._prepare_express_checkout_values(order_sudo, **query_params)
+        return request.render("website_sale_express_checkout.express_checkout", render_values)
+
+    def _prepare_express_checkout_values(self, order_sudo, **kwargs):
+        # Reuse the native checkout page + address form values.
+        values = self._prepare_checkout_page_values(order_sudo, **kwargs)
+        # Prefill from the DELIVERY contact, not the order's main partner: this form
+        # is the contact + shipping address. For Consumidor Final both are the same
+        # partner; for Factura A the main partner is the billing one (razón social +
+        # fiscal domicile), so prefilling from it would show the fiscal name/address
+        # over the delivery fields (and risk shipping to the fiscal address on a
+        # re-confirm). Anonymous cart -> blank form (the public user must not leak).
+        if order_sudo._is_anonymous_cart():
+            partner_sudo = request.env["res.partner"].sudo()
+        else:
+            partner_sudo = order_sudo.partner_shipping_id or order_sudo.partner_id
+        values.update(
+            self._prepare_address_form_values(
+                partner_sudo,
+                address_type="billing",
+                use_delivery_as_billing=True,
+                order_sudo=order_sudo,
+                **kwargs,
+            )
+        )
+        # The buyer takes no tax decision: hide the whole billing/b2b block (which
+        # carries company_name, VAT and the ARCA responsibility select). The CUIT
+        # for the Factura A path is rendered by the express page itself.
+        values["is_used_as_billing"] = False
+        # AR-only: default the (hidden) country to Argentina so the province field
+        # renders (AR is state_required) and the interaction loads AR states. It is
+        # also submitted, so country_id/state_id pass validation before the server
+        # forces the country in _complete_address_values.
+        ar_country = request.env.ref("base.ar")
+        values["country"] = ar_country
+        values["country_states"] = ar_country.state_ids
+        # Responsibility options for the Factura A manual path (when ARCA can't be
+        # reached, the buyer picks it themselves).
+        values["express_responsibility_types"] = request.env["l10n_ar.afip.responsibility.type"].sudo().search([])
+        # Restore the Factura A state when coming back to the page after a submit:
+        # the billing partner (partner_invoice_id, separate from the delivery one
+        # and carrying a CUIT) holds the fiscal data, so we re-check the box and
+        # prefill the CUIT + fiscal fields without re-querying ARCA.
+        billing_sudo = order_sudo.partner_invoice_id
+        is_factura_a = bool(
+            not order_sudo._is_anonymous_cart()
+            and billing_sudo
+            and billing_sudo != order_sudo.partner_shipping_id
+            and billing_sudo.l10n_latam_identification_type_id == request.env.ref("l10n_ar.it_cuit")
+        )
+        values["express_factura_a"] = is_factura_a
+        values["express_fa_billing"] = billing_sudo if is_factura_a else request.env["res.partner"].sudo()
+        # delivery_form needs `delivery_methods` in context. We only list the
+        # carriers; the rate is resolved client-side via the jsonrpc delivery
+        # routes once the buyer enters an address (it cannot be computed here).
+        if order_sudo._has_deliverable_products():
+            values["delivery_methods"] = order_sudo._get_delivery_methods()
+        # checkout_layout -> navigation_buttons needs the step nav values.
+        values.update(request.website._get_checkout_step_values())
+        return values
+
+    # ------------------------------------------------------------------
+    # Live ARCA padron lookup (Factura A)
+    # ------------------------------------------------------------------
+    @route(
+        "/shop/express_checkout/padron_lookup",
+        type="jsonrpc",
+        auth="public",
+        website=True,
+    )
+    def express_checkout_padron_lookup(self, vat=None):
+        """Look up the fiscal data of a CUIT in the ARCA padron.
+
+        Thin route wrapper: the actual work lives in ``_express_padron_lookup``
+        so the padron bridge can override the logic without re-decorating the
+        route (and so tests can call it directly without the routing wrapper).
+
+        :return: ``{"available": bool, "success": bool, "values": dict}``. When
+                 ``available`` is False (or ``success`` is False), the client
+                 renders the fiscal fields editable for manual entry.
+        """
+        return self._express_padron_lookup(vat)
+
+    def _express_padron_lookup(self, vat=None):
+        """Base module: ARCA is not available (no EE) -> manual entry.
+
+        The ``website_sale_express_checkout_padron`` bridge overrides this to
+        run the real query.
+        """
+        return {"available": False}
+
+    # ------------------------------------------------------------------
+    # Shared hooks — scoped to the express flow
+    # ------------------------------------------------------------------
+    def _parse_form_data(self, form_data):
+        address_values, extra_form_data = super()._parse_form_data(form_data)
+        if getattr(request, "express_checkout_flow", False) and not getattr(
+            request, "express_checkout_factura_a", False
+        ):
+            # Consumidor Final: the responsibility is assigned server-side, so a
+            # forged value is discarded. The id type is derived from the document
+            # shape (DNI vs CUIT) — not trusted from the form — and set together
+            # with the vat so the l10n_ar identification constraint validates
+            # against the right type when the partner is written.
+            address_values.pop("l10n_ar_afip_responsibility_type_id", None)
+            vat = address_values.get("vat")
+            if vat:
+                digits = "".join(filter(str.isdigit, vat))
+                id_xmlid = "l10n_ar.it_cuit" if len(digits) == 11 else "l10n_ar.it_dni"
+                address_values["l10n_latam_identification_type_id"] = request.env.ref(id_xmlid).id
+            else:
+                address_values.pop("l10n_latam_identification_type_id", None)
+        return address_values, extra_form_data
+
+    # Fields that l10n_latam_base / l10n_ar force as mandatory for AR billing but
+    # that this flow derives server-side (responsibility, id type) or does not ask
+    # a Consumidor Final (vat). We relax them in the *consumers* of the mandatory
+    # set — _validate_address_values (submit) and _check_billing_address (payment
+    # gate) — instead of _get_mandatory_billing_address_fields, because those
+    # localization overrides re-add the fields AFTER ours in the MRO, defeating a
+    # discard there.
+    _EXPRESS_DERIVED_FIELDS = frozenset(
+        {
+            "l10n_ar_afip_responsibility_type_id",
+            "l10n_latam_identification_type_id",
+        }
+    )
+
+    def _validate_address_values(self, address_values, *args, **kwargs):
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values, *args, **kwargs
+        )
+        if not getattr(request, "express_checkout_flow", False):
+            return invalid_fields, missing_fields, error_messages
+        # Consumidor Final: responsibility + id type are derived server-side, so
+        # they are relaxed. The document (vat/DNI) IS asked, so it is not relaxed.
+        # Factura A carries all of them from the form (ARCA-verified or entered by
+        # hand), so nothing is relaxed there.
+        optional = set()
+        if not getattr(request, "express_checkout_factura_a", False):
+            optional = set(self._EXPRESS_DERIVED_FIELDS)
+        had_missing = bool(missing_fields)
+        invalid_fields = invalid_fields - optional
+        missing_fields = missing_fields - optional
+        if had_missing and not missing_fields:
+            msg = request.env._("Some required fields are empty.")
+            error_messages = [m for m in error_messages if m != msg]
+        # Beyond the native "not empty" check, the zip must have at least 4
+        # characters to proceed (matches the client-side validation).
+        zip_code = (address_values.get("zip") or "").strip()
+        if zip_code and len(zip_code) < 4:
+            invalid_fields.add("zip")
+            error_messages.append(request.env._("The zip code must have at least 4 characters."))
+        return invalid_fields, missing_fields, error_messages
+
+    def _check_billing_address(self, partner_sudo):
+        if super()._check_billing_address(partner_sudo):
+            return True
+        # On an express AR website the derived/optional fields must not block the
+        # payment gate (this request has no express_checkout_flow flag set).
+        website = request.website
+        if website.enable_express_checkout and partner_sudo.country_id.code == "AR":
+            mandatory = self._get_mandatory_billing_address_fields(partner_sudo.country_id)
+            mandatory = list(mandatory - self._EXPRESS_DERIVED_FIELDS - {"vat"})
+            return all(partner_sudo.read(mandatory)[0].values())
+        return False
+
+    def _complete_address_values(self, address_values, address_type, use_delivery_as_billing, **kwargs):
+        super()._complete_address_values(address_values, address_type, use_delivery_as_billing, **kwargs)
+        if getattr(request, "express_checkout_flow", False):
+            # AR-only: country is fixed for every partner created in this flow. The
+            # tax identity (responsibility, id type) is applied explicitly in
+            # _express_apply_tax_identity, so it works whether the partner is newly
+            # created or a provisional one being updated.
+            address_values["country_id"] = request.env.ref("base.ar").id
+
+    def _express_apply_tax_identity(self, partner_sudo, factura_a):
+        """Set country + the AR id type on the (already saved) main partner.
+
+        Factura A: the id type is always CUIT (the buyer entered one); the
+        responsibility comes from the form (ARCA-verified or entered by hand) and
+        is left untouched. Consumidor Final: derive the responsibility (CF) and the
+        id type from the document shape. Kept out of _complete_address_values
+        (create-only) so it also applies to the provisional partner reused by the
+        CF path. C9: an existing responsibility is never overwritten."""
+        env = request.env
+        vals = {"country_id": env.ref("base.ar").id}
+        if factura_a:
+            vals["l10n_latam_identification_type_id"] = env.ref("l10n_ar.it_cuit").id
+        elif not partner_sudo.l10n_ar_afip_responsibility_type_id:
+            digits = "".join(filter(str.isdigit, partner_sudo.vat or ""))
+            id_type = "l10n_ar.it_cuit" if len(digits) == 11 else "l10n_ar.it_dni"
+            vals["l10n_latam_identification_type_id"] = env.ref(id_type).id
+            vals["l10n_ar_afip_responsibility_type_id"] = env.ref("l10n_ar.res_CF").id
+        partner_sudo.sudo().write(vals)
+
+    # ------------------------------------------------------------------
+    # Submit
+    # ------------------------------------------------------------------
+    @route(
+        "/shop/express_checkout/submit",
+        type="http",
+        methods=["POST"],
+        auth="public",
+        website=True,
+        sitemap=False,
+    )
+    def express_checkout_submit(
+        self,
+        factura_a=None,
+        use_delivery_as_billing=None,
+        address_type=None,
+        callback=None,
+        **form_data,
+    ):
+        """Single submit for the whole express form.
+
+        ``use_delivery_as_billing`` / ``address_type`` / ``callback`` are captured
+        out of ``form_data`` (the inherited address form injects them as hidden
+        inputs) and intentionally ignored: we derive the flow from ``factura_a``
+        and always advance to the payment step. Leaving them in ``form_data`` would
+        collide with the explicit keyword args downstream.
+
+        Consumidor Final: one partner (invoice == shipping == partner_id), tax
+        identity derived server-side.
+
+        Factura A: the billing partner is built from the fiscal fields the buyer
+        confirmed (ARCA-verified or entered by hand): ``fa_name`` (razón social),
+        the CUIT, ``fa_responsibility`` and the fiscal domicile (``fa_*``). A
+        separate ``type='delivery'`` child carries the buyer's shipping address.
+        """
+        order_sudo = request.cart
+        if redirection := self._check_cart(order_sudo):
+            return json.dumps({"redirectUrl": redirection.location})
+        if not self._express_checkout_enabled(order_sudo):
+            return json.dumps({"redirectUrl": "/shop/checkout"})
+
+        factura_a = str2bool(factura_a or "false")
+        request.express_checkout_flow = True
+        request.express_checkout_factura_a = factura_a
+
+        if factura_a:
+            feedback = self._express_submit_factura_a(order_sudo, **form_data)
+        else:
+            _partner, feedback = self._express_create_or_update_main(order_sudo, factura_a=False, **form_data)
+        if feedback.get("invalid_fields"):
+            return json.dumps(feedback)
+
+        # Safety net: if the buyer never picked a carrier, set the preferred one so
+        # the payment step doesn't reject the order for a missing shipping method.
+        self._express_ensure_delivery_method(order_sudo)
+
+        # Advance to the extra-info step: when it is not active the native
+        # controller forwards straight to /shop/payment, so this honors a
+        # configured extra step without us re-implementing its gate. We do not
+        # honor a caller-provided redirect target: a forged POST could otherwise
+        # turn this into an open redirect.
+        return json.dumps({"redirectUrl": "/shop/extra_info"})
+
+    def _express_submit_factura_a(self, order_sudo, **form_data):
+        """Build the billing partner from the fiscal (fa_*) fields and the delivery
+        child from the shipping address, then wire both to the order."""
+        billing_data = self._express_factura_a_billing_data(form_data)
+        # Reuse the partner provisioned during delivery rating (order.partner_id on
+        # a no-longer-anonymous cart) — or the logged-in partner — as the billing
+        # partner, exactly like the CF path. Otherwise a fresh partner would be
+        # created as a CHILD of that provisional "Checkout" partner, leaving it
+        # orphaned as a spurious parent of both the billing and delivery contacts.
+        if order_sudo._is_anonymous_cart():
+            partner_sudo = request.env["res.partner"].with_context(show_address=1).sudo().browse()
+        else:
+            partner_sudo = order_sudo.partner_id
+        billing_sudo, feedback = self._create_or_update_address(
+            partner_sudo,
+            address_type="billing",
+            use_delivery_as_billing="false",
+            callback="/shop/payment",
+            order_sudo=order_sudo,
+            **billing_data,
+        )
+        if feedback.get("invalid_fields"):
+            return feedback
+        # Country only; the responsibility/id type come from the form (C9 in
+        # _express_apply_tax_identity keeps the submitted responsibility).
+        self._express_apply_tax_identity(billing_sudo, factura_a=True)
+        order_sudo._update_address(billing_sudo.id, {"partner_id", "partner_invoice_id"})
+        if order_sudo._is_anonymous_cart():
+            order_sudo.message_unsubscribe(order_sudo.website_id.partner_id.ids)
+        # Delivery child carries the buyer's shipping address (the contact block).
+        return self._express_create_delivery_child(order_sudo, billing_sudo, **form_data)
+
+    def _express_factura_a_billing_data(self, form_data):
+        """Map the fiscal (fa_*) form fields to res.partner billing values."""
+        env = request.env
+        return {
+            "name": form_data.get("fa_name") or "",
+            "email": form_data.get("email") or "",
+            "phone": form_data.get("phone") or "",
+            "vat": form_data.get("vat") or "",
+            "street": form_data.get("fa_street") or "",
+            "city": form_data.get("fa_city") or "",
+            "zip": form_data.get("fa_zip") or "",
+            "state_id": form_data.get("fa_state_id") or "",
+            "country_id": str(env.ref("base.ar").id),
+            "l10n_ar_afip_responsibility_type_id": form_data.get("fa_responsibility") or "",
+            "l10n_latam_identification_type_id": str(env.ref("l10n_ar.it_cuit").id),
+        }
+
+    def _express_ensure_delivery_method(self, order_sudo):
+        if not order_sudo._has_deliverable_products() or order_sudo.carrier_id:
+            return
+        available = order_sudo._get_delivery_methods()
+        preferred = order_sudo._get_preferred_delivery_method(available) if available else available
+        if preferred:
+            order_sudo._set_delivery_method(preferred)
+
+    # ------------------------------------------------------------------
+    # Delivery rating — compute + render methods once the address is known
+    # ------------------------------------------------------------------
+    @route(
+        "/shop/express_checkout/delivery_methods",
+        type="jsonrpc",
+        auth="public",
+        website=True,
+    )
+    def express_checkout_delivery_methods(self, **form):
+        """Persist the entered form and return the rendered delivery form so the
+        carriers can be rated and selected on the single page."""
+        order_sudo = request.cart
+        if not order_sudo or not self._express_checkout_enabled(order_sudo):
+            return {"delivery_form": ""}
+        if not order_sudo._has_deliverable_products():
+            return {"delivery_form": ""}
+        request.express_checkout_flow = True
+        if not self._express_persist_form(order_sudo, form):
+            return {"delivery_form": ""}
+        values = {
+            "delivery_methods": order_sudo._get_delivery_methods(),
+            "selected_dm_id": order_sudo.carrier_id.id,
+            "order": order_sudo,
+        }
+        return {"delivery_form": request.env["ir.ui.view"]._render_template("website_sale.delivery_form", values)}
+
+    @route(
+        "/shop/express_checkout/save",
+        type="jsonrpc",
+        auth="public",
+        website=True,
+    )
+    def express_checkout_save(self, **form):
+        """Persist the buyer's form on the (provisional) partner without touching
+        the delivery methods, so contact/document fields typed after the address
+        also survive navigating away and back."""
+        order_sudo = request.cart
+        if not order_sudo or not self._express_checkout_enabled(order_sudo):
+            return {}
+        request.express_checkout_flow = True
+        self._express_persist_form(order_sudo, form)
+        return {}
+
+    def _express_persist_form(self, order_sudo, form):
+        """Store the buyer's contact + address (+ CF document) on the cart's
+        partner so the express form survives navigating away and back.
+
+        Anonymous cart: provision a partner (with the real name) once the address
+        can rate, and set it as the cart's partner (partner_shipping/invoice are
+        computed from it); the submit reuses this partner. Guest with that
+        provisional partner: rewrite the whole form onto it. Logged-in: only
+        refresh the shipping address, never the account's contact data.
+
+        Returns whether the address is complete enough to rate (zip >= 4 digits +
+        province)."""
+        guest = request.env.user._is_public()
+        keys = set(_EXPRESS_CONTACT_FIELDS) | set(_ADDRESS_FIELDS) | {"vat"}
+        vals = {key: value for key, value in form.items() if key in keys and value}
+        # Only persist a document once it is a complete DNI (7-8) or CUIT (11):
+        # partial typing would fail the l10n_ar identification constraint on write.
+        doc_digits = "".join(ch for ch in (vals.get("vat") or "") if ch.isdigit())
+        if len(doc_digits) not in (7, 8, 11):
+            vals.pop("vat", None)
+        zip_digits = "".join(ch for ch in (vals.get("zip") or "") if ch.isdigit())
+        address_ready = len(zip_digits) >= 4 and bool(vals.get("state_id"))
+        vals["country_id"] = str(request.env.ref("base.ar").id)
+        address_values, _extra = self._parse_form_data(vals)
+        if order_sudo._is_anonymous_cart():
+            if not (guest and address_ready):
+                return False
+            # Provision with the buyer's real name (a neutral fallback only if they
+            # completed the address before typing it; the next save fixes it).
+            address_values.setdefault("name", request.env._("Cliente"))
+            new_partner = self._create_new_address(
+                address_values,
+                address_type="delivery",
+                use_delivery_as_billing=False,
+                order_sudo=order_sudo,
+            )
+            # Don't recompute the pricelist just because the partner changed.
+            with request.env.protecting([order_sudo._fields["pricelist_id"]], order_sudo):
+                order_sudo.partner_id = new_partner
+        elif guest:
+            # Our provisional partner: rewrite the whole form so it survives navigation.
+            order_sudo.partner_id.sudo().write(address_values)
+        else:
+            # Logged-in: only refresh the shipping address; never clobber their contact.
+            shipping_values = {
+                key: value for key, value in address_values.items() if key in set(_ADDRESS_FIELDS) | {"country_id"}
+            }
+            if shipping_values:
+                order_sudo.partner_shipping_id.sudo().write(shipping_values)
+        return address_ready
+
+    def _express_create_or_update_main(self, order_sudo, factura_a=False, **form_data):
+        """Create/update the main (billing) partner and wire it to the order.
+
+        Reuses the partner provisioned during delivery rating (order.partner_id on
+        a no-longer-anonymous cart) so the carrier and address survive; otherwise
+        creates a fresh one. The AR tax identity is applied explicitly afterwards
+        (so it works on both the create and the update path)."""
+        use_delivery_as_billing = not factura_a
+        was_anonymous = order_sudo._is_anonymous_cart()
+        if was_anonymous:
+            partner_sudo = request.env["res.partner"].with_context(show_address=1).sudo().browse()
+        else:
+            partner_sudo = order_sudo.partner_id
+
+        partner_sudo, feedback = self._create_or_update_address(
+            partner_sudo,
+            address_type="billing",
+            use_delivery_as_billing="true" if use_delivery_as_billing else "false",
+            callback="/shop/payment",
+            order_sudo=order_sudo,
+            **form_data,
+        )
+        if feedback.get("invalid_fields"):
+            return partner_sudo, feedback
+
+        self._express_apply_tax_identity(partner_sudo, factura_a)
+
+        partner_fnames = {"partner_id", "partner_invoice_id"}
+        if use_delivery_as_billing:
+            partner_fnames.add("partner_shipping_id")
+        order_sudo._update_address(partner_sudo.id, partner_fnames)
+
+        if was_anonymous:
+            order_sudo.message_unsubscribe(order_sudo.website_id.partner_id.ids)
+        return partner_sudo, feedback
+
+    def _express_create_delivery_child(self, order_sudo, main_partner_sudo, **form_data):
+        """Create the delivery child (buyer's address) and set it as shipping."""
+        delivery_data = {key: value for key, value in form_data.items() if key in _ADDRESS_FIELDS}
+        # The delivery address validation requires name/email/phone/country_id too
+        # (they are mandatory for a delivery address). Carry the contact data from
+        # the main partner and fix the country (AR) so validation passes — the
+        # server would otherwise only set the country in _complete_address_values,
+        # which runs after validation.
+        delivery_data["country_id"] = request.env.ref("base.ar").id
+        # The recipient is the contact the buyer entered (not the billing razón
+        # social); fall back to the main partner's data.
+        delivery_data.setdefault("name", form_data.get("name") or main_partner_sudo.name)
+        delivery_data.setdefault("email", form_data.get("email") or main_partner_sudo.email or "")
+        delivery_data.setdefault("phone", form_data.get("phone") or main_partner_sudo.phone or "")
+
+        # Reuse the existing delivery child on a re-submit (e.g. the buyer went back
+        # and confirmed again) instead of creating a new one each time. The order's
+        # shipping partner is that child only when it differs from the billing
+        # partner; otherwise (first submit) it still points at the billing/main one,
+        # so we create a fresh child.
+        existing_child = order_sudo.partner_shipping_id
+        target = (
+            existing_child.with_context(show_address=1).sudo()
+            if existing_child and existing_child != main_partner_sudo
+            else request.env["res.partner"].with_context(show_address=1).sudo().browse()
+        )
+        child_sudo, feedback = self._create_or_update_address(
+            target,
+            address_type="delivery",
+            use_delivery_as_billing="false",
+            callback="/shop/payment",
+            order_sudo=order_sudo,
+            **delivery_data,
+        )
+        if not feedback.get("invalid_fields"):
+            order_sudo._update_address(child_sudo.id, {"partner_shipping_id"})
+        return feedback

--- a/website_sale_express_checkout/data/website_checkout_step_data.xml
+++ b/website_sale_express_checkout/data/website_checkout_step_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Generic step (website_id = False). website._create_checkout_steps copies
+         it per website; publication is driven by website.enable_express_checkout. -->
+    <record id="checkout_step_express" model="website.checkout.step">
+        <field name="name">Checkout</field>
+        <field name="sequence">250</field>
+        <field name="step_href">/shop/express_checkout</field>
+        <field name="main_button_label">Confirm</field>
+        <field name="back_button_label">Back to cart</field>
+        <field name="is_published" eval="False"/>
+    </record>
+
+</odoo>

--- a/website_sale_express_checkout/hooks.py
+++ b/website_sale_express_checkout/hooks.py
@@ -1,0 +1,39 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+EXPRESS_HREF = "/shop/express_checkout"
+DELIVERY_HREF = "/shop/checkout"
+EXTRA_HREF = "/shop/extra_info"
+
+
+def post_init_hook(env):
+    """Propagate the generic ``express_checkout`` step to every existing website.
+
+    New websites get it through ``website._create_checkout_steps`` (which copies
+    every generic step); pre-existing websites need it copied here. Publication
+    is then synced from each website's ``enable_express_checkout`` flag, which is
+    ``False`` by default -> installing the module leaves the standard flow intact.
+    """
+    generic_step = env.ref("website_sale_express_checkout.checkout_step_express", raise_if_not_found=False)
+    for website in env["website"].search([]):
+        if generic_step and not website._get_checkout_step(EXPRESS_HREF):
+            generic_step.copy({"website_id": website.id, "is_published": False})
+        website._sync_express_checkout_steps()
+
+
+def uninstall_hook(env):
+    """Remove the per-website express step and restore delivery/extra publication."""
+    Step = env["website.checkout.step"].sudo()
+    for website in env["website"].search([]):
+        Step.search(
+            [
+                ("website_id", "=", website.id),
+                ("step_href", "=", EXPRESS_HREF),
+            ]
+        ).unlink()
+        delivery = website._get_checkout_step(DELIVERY_HREF)
+        extra = website._get_checkout_step(EXTRA_HREF)
+        delivery.is_published = True
+        # extra_info follows the view's active state, as core does on step creation
+        extra.is_published = website.with_context(website_id=website.id).viewref("website_sale.extra_info").active

--- a/website_sale_express_checkout/models/__init__.py
+++ b/website_sale_express_checkout/models/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import website
+from . import res_config_settings

--- a/website_sale_express_checkout/models/res_config_settings.py
+++ b/website_sale_express_checkout/models/res_config_settings.py
@@ -1,0 +1,14 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    enable_express_checkout = fields.Boolean(
+        related="website_id.enable_express_checkout",
+        readonly=False,
+    )

--- a/website_sale_express_checkout/models/website.py
+++ b/website_sale_express_checkout/models/website.py
@@ -1,0 +1,49 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+EXPRESS_HREF = "/shop/express_checkout"
+DELIVERY_HREF = "/shop/checkout"
+EXTRA_HREF = "/shop/extra_info"
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    enable_express_checkout = fields.Boolean(
+        string="Express Checkout (AR)",
+        help="Collapse the eCommerce checkout into a single page and derive the "
+        "Argentinean tax data server-side. Only takes effect when the cart's "
+        "company is Argentinean; other companies keep the native flow.",
+    )
+
+    def _create_checkout_steps(self):
+        # super() copies every generic step (including our express_checkout one)
+        # into a per-website record; then we set publication from the flag.
+        super()._create_checkout_steps()
+        self._sync_express_checkout_steps()
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "enable_express_checkout" in vals:
+            self._sync_express_checkout_steps()
+            if vals.get("enable_express_checkout"):
+                # Background invoice validation is mandatory: a synchronous ARCA
+                # call inside the payment request would break cart confirmation.
+                self.company_id.sudo().website_sale_background_post = True
+        return res
+
+    def _sync_express_checkout_steps(self):
+        """Publish express_checkout and hide delivery/extra (or the inverse)."""
+        for website in self:
+            express = website._get_checkout_step(EXPRESS_HREF)
+            delivery = website._get_checkout_step(DELIVERY_HREF)
+            extra = website._get_checkout_step(EXTRA_HREF)
+            express.is_published = website.enable_express_checkout
+            delivery.is_published = not website.enable_express_checkout
+            # The extra-info step follows the view's active state (as core does)
+            # in both modes: the express flow routes through it when the merchant
+            # enabled it, and skips it otherwise.
+            extra.is_published = website.with_context(website_id=website.id).viewref("website_sale.extra_info").active

--- a/website_sale_express_checkout/static/src/interactions/express_checkout.js
+++ b/website_sale_express_checkout/static/src/interactions/express_checkout.js
@@ -1,0 +1,436 @@
+/** @odoo-module **/
+import { CustomerAddress } from '@portal/interactions/address';
+import { patch } from '@web/core/utils/patch';
+import { rpc } from '@web/core/network/rpc';
+
+// Address fields whose completion triggers the delivery-method rating.
+const DELIVERY_ADDRESS_FIELDS = ['street', 'city', 'zip', 'state_id'];
+const CUIT_LENGTH = 11;
+
+// Extends the native portal.customer_address interaction (which already handles
+// the submit to data-submit-url, error rendering and the AR state loading) with
+// the express-checkout specifics: the Factura A flow (CUIT validation + live ARCA
+// lookup) and the on-page delivery-method rating. Guarded by the express nodes so
+// the patch is inert on /my/address and /shop/address.
+patch(CustomerAddress.prototype, {
+
+    setup() {
+        super.setup();
+        this.expressForm = this.addressForm?.classList.contains('o_express_checkout_form');
+        if (!this.expressForm) {
+            return;
+        }
+        const qs = (sel) => this.addressForm.querySelector(sel);
+        // ---- Factura A ----
+        this.facturaACheckbox = qs('#express_factura_a');
+        this.facturaAFields = qs('#express_factura_a_fields');
+        this.vatInput = qs('#express_vat');
+        this.vatStatus = qs('#express_vat_status');
+        this.vatMsg = qs('#express_vat_msg');
+        this.faDetails = qs('#express_fa_details');
+        // Consumidor Final document (shares name="vat" with the FA CUIT input).
+        this.dniInput = qs('#express_dni');
+        this.dniContainer = qs('#div_express_dni');
+        this.faFields = {
+            fa_responsibility: qs('#express_fa_responsibility'),
+            fa_name: qs('#express_fa_name'),
+            fa_street: qs('#express_fa_street'),
+            fa_zip: qs('#express_fa_zip'),
+            fa_city: qs('#express_fa_city'),
+            fa_state_id: qs('#express_fa_state'),
+        };
+        if (this.facturaACheckbox) {
+            // A user toggle never restores (that path is only for the initial load
+            // of a server-prefilled Factura A); the change event's argument must not
+            // leak into the `restore` parameter.
+            this._boundFaToggle = () => this._onFacturaAToggle(false);
+            this.facturaACheckbox.addEventListener('change', this._boundFaToggle);
+        }
+        if (this.vatInput) {
+            this._boundCuitInput = this._onCuitInput.bind(this);
+            this.vatInput.addEventListener('input', this._boundCuitInput);
+            this._debouncedLookup = this.debounced(this._lookupPadron, 400);
+        }
+        if (this.facturaACheckbox) {
+            // On load, restore a server-prefilled Factura A (came back after submit)
+            // instead of re-querying ARCA.
+            this._onFacturaAToggle(this.facturaACheckbox.checked);
+        }
+        // ---- Zip: at least 4 characters to proceed ----
+        this.zipInput = qs('[name="zip"]');
+        if (this.zipInput) {
+            this._boundCheckZip = this._checkZip.bind(this);
+            this.zipInput.addEventListener('input', this._boundCheckZip);
+            this._checkZip();
+        }
+        // ---- Delivery: rate + enable the methods once the address is complete ----
+        this.deliveryContainer = document.querySelector('#express_delivery_container');
+        if (this.deliveryContainer) {
+            this._boundRefreshDelivery = this.debounced(this._refreshDeliveryMethods, 600);
+            this._deliveryFields = DELIVERY_ADDRESS_FIELDS
+                .map((name) => qs(`[name="${name}"]`))
+                .filter(Boolean);
+            this._deliveryFields.forEach((el) => {
+                el.addEventListener('change', this._boundRefreshDelivery);
+                el.addEventListener('input', this._boundRefreshDelivery);
+            });
+        }
+        // ---- Persist contact/document fields so the form survives navigation ----
+        // The address fields already persist through the delivery rating above; the
+        // contact + DNI fields save through their own lightweight endpoint.
+        this._boundPersist = this.debounced(this._persistForm, 700);
+        this._persistFields = [
+            qs('[name="name"]'), qs('[name="email"]'), qs('[name="phone"]'), this.dniInput,
+        ].filter(Boolean);
+        this._persistFields.forEach((el) => {
+            el.addEventListener('change', this._boundPersist);
+            el.addEventListener('input', this._boundPersist);
+        });
+    },
+
+    destroy() {
+        this.facturaACheckbox?.removeEventListener('change', this._boundFaToggle);
+        this.vatInput?.removeEventListener('input', this._boundCuitInput);
+        this.zipInput?.removeEventListener('input', this._boundCheckZip);
+        this._deliveryFields?.forEach((el) => {
+            el.removeEventListener('change', this._boundRefreshDelivery);
+            el.removeEventListener('input', this._boundRefreshDelivery);
+        });
+        this._persistFields?.forEach((el) => {
+            el.removeEventListener('change', this._boundPersist);
+            el.removeEventListener('input', this._boundPersist);
+        });
+        super.destroy();
+    },
+
+    // ==================================================================
+    // Factura A
+    // ==================================================================
+    // restore=true only on the initial load of a Factura A that came back
+    // server-prefilled (after a submit): show the fiscal fields with their values
+    // and lock the filled ones, WITHOUT re-querying ARCA.
+    _onFacturaAToggle(restore = false) {
+        const on = this.facturaACheckbox.checked;
+        this.facturaAFields.classList.toggle('d-none', !on);
+        this.vatInput.required = on;
+        // Only the active document input is submitted (they share name="vat"):
+        // FA -> CUIT enabled, DNI disabled; CF -> DNI enabled, CUIT disabled.
+        this.vatInput.disabled = !on;
+        if (this.dniInput) {
+            this.dniInput.disabled = on;
+            this.dniInput.required = !on;
+            this.dniContainer?.classList.toggle('d-none', on);
+        }
+        if (!on) {
+            // Back to Consumidor Final: clear everything, no fiscal fields, and
+            // make sure the confirm button is not left disabled by a pending lookup.
+            this.vatInput.value = '';
+            this.vatInput.setCustomValidity('');
+            this._setVatStatus('none');
+            this.vatMsg?.classList.add('d-none');
+            this._collapseFaDetails();
+            this._clearFaFields();
+            this._setSubmitEnabled(true);
+        } else if (restore) {
+            // Format the prefilled CUIT and lock the filled fiscal fields (empty
+            // ones stay editable) — no ARCA call.
+            this.vatInput.value = this._formatCuit(this.vatInput.value.replace(/\D/g, '').slice(0, CUIT_LENGTH));
+            this.faDetails.classList.remove('d-none');
+            Object.values(this.faFields).forEach((el) => {
+                if (el) {
+                    this._lockFaField(el, Boolean(el.value));
+                }
+            });
+            this._setVatStatus('ok');
+        } else {
+            this._onCuitInput();
+        }
+    },
+
+    _onCuitInput() {
+        const digits = this.vatInput.value.replace(/\D/g, '').slice(0, CUIT_LENGTH);
+        // Format as XX-XXXXXXXX-X while the buyer types or pastes.
+        this.vatInput.value = this._formatCuit(digits);
+        if (!this.facturaACheckbox.checked) {
+            return;
+        }
+        // Not a full CUIT yet: keep the field invalid (blocks submit), no fiscal fields.
+        if (digits.length < CUIT_LENGTH) {
+            this._setVatStatus('none');
+            this.vatMsg?.classList.add('d-none');
+            this._collapseFaDetails();
+            this._clearFaFields();
+            this._setSubmitEnabled(true);
+            this.vatInput.setCustomValidity(digits.length ? 'CUIT incompleto.' : '');
+            return;
+        }
+        // Full CUIT: validate the check digit before hitting ARCA.
+        if (!this._isValidCuit(digits)) {
+            this._setVatStatus('error');
+            this.vatMsg?.classList.remove('d-none');
+            this._collapseFaDetails();
+            this._clearFaFields();
+            this._setSubmitEnabled(true);
+            this.vatInput.setCustomValidity('El CUIT ingresado no es válido.');
+            return;
+        }
+        // Valid CUIT: clear any previous result so a failing/empty response can't
+        // leave stale data, disable the confirm button while ARCA is queried, then
+        // spinner + lookup.
+        this._clearFaFields();
+        this._collapseFaDetails();
+        this.vatMsg?.classList.add('d-none');
+        this.vatInput.setCustomValidity('');
+        this._setVatStatus('spinner');
+        this._setSubmitEnabled(false);
+        this._debouncedLookup(digits);
+    },
+
+    _formatCuit(digits) {
+        if (digits.length <= 2) {
+            return digits;
+        }
+        if (digits.length <= 10) {
+            return `${digits.slice(0, 2)}-${digits.slice(2)}`;
+        }
+        return `${digits.slice(0, 2)}-${digits.slice(2, 10)}-${digits.slice(10)}`;
+    },
+
+    // Enable/disable the checkout confirm button(s) — used to block advancing
+    // while the ARCA lookup is in flight. Bootstrap's .disabled on the <a> button
+    // sets pointer-events:none, so the click (and its submit handler) can't fire.
+    _setSubmitEnabled(enabled) {
+        const buttons = this.submitButtons || document.getElementsByName('website_sale_main_button');
+        Array.from(buttons).forEach((b) => b.classList.toggle('disabled', !enabled));
+    },
+
+    async _lookupPadron(cuit) {
+        let res;
+        try {
+            res = await this.waitFor(rpc('/shop/express_checkout/padron_lookup', { vat: cuit }));
+        } catch {
+            res = null;
+        }
+        // Ignore a stale response if the CUIT changed meanwhile.
+        if (this.vatInput.value.replace(/\D/g, '') !== cuit) {
+            this._setSubmitEnabled(true);
+            return;
+        }
+        // Always show the fiscal section with an editable+required baseline; then,
+        // if ARCA answered, lock ONLY the fields it actually returned and leave the
+        // ones it left empty editable so the buyer can complete them (Marco's
+        // request: never leave an empty field disabled and blocking the checkout).
+        this._showFaDetails(true);
+        if (res && res.available && res.found && res.values) {
+            this._setVatStatus('ok');
+            this._fillFaFields(res.values);
+        } else {
+            // ARCA could not resolve the CUIT: manual entry, everything editable.
+            this._setVatStatus('none');
+        }
+        // Re-enable the confirm button now that the lookup has resolved.
+        this._setSubmitEnabled(true);
+    },
+
+    _setVatStatus(kind) {
+        if (!this.vatStatus) {
+            return;
+        }
+        const icons = {
+            spinner: '<span class="fa fa-spinner fa-spin"/>',
+            ok: '<span class="fa fa-check text-success"/>',
+            error: '<span class="fa fa-times text-danger"/>',
+        };
+        this.vatStatus.innerHTML = icons[kind] || '';
+        this.vatStatus.classList.toggle('d-none', !icons[kind]);
+    },
+
+    _collapseFaDetails() {
+        this.faDetails?.classList.add('d-none');
+        Object.values(this.faFields).forEach((el) => {
+            if (el) {
+                el.required = false;
+            }
+        });
+    },
+
+    // Show the fiscal section with an editable + required baseline. Fields ARCA
+    // returns are locked afterwards, one by one, in _fillFaFields.
+    _showFaDetails(editable) {
+        this.faDetails.classList.remove('d-none');
+        Object.values(this.faFields).forEach((el) => {
+            if (el) {
+                this._lockFaField(el, !editable);
+            }
+        });
+    },
+
+    // Lock (ARCA-provided, read-only/greyed) or unlock (buyer must fill, required)
+    // a single fiscal field.
+    _lockFaField(el, locked) {
+        el.required = !locked;
+        if (el.tagName === 'SELECT') {
+            el.classList.toggle('pe-none', locked);
+            el.classList.toggle('opacity-50', locked);
+        } else {
+            el.readOnly = locked;
+            el.classList.toggle('bg-light', locked);
+        }
+    },
+
+    _clearFaFields() {
+        Object.values(this.faFields).forEach((el) => {
+            if (!el) {
+                return;
+            }
+            el.value = '';
+            el.required = false;
+            el.readOnly = false;
+            el.classList.remove('bg-light', 'pe-none', 'opacity-50');
+        });
+    },
+
+    // Per field: if ARCA returned a value, set it and lock the field; if it came
+    // back empty, leave the field editable and required so the buyer completes it.
+    _fillFaFields(values) {
+        const apply = (el, v) => {
+            if (!el) {
+                return;
+            }
+            const value = v != null && v !== false ? String(v) : '';
+            el.value = value;
+            this._lockFaField(el, Boolean(value));
+        };
+        apply(this.faFields.fa_responsibility, values.l10n_ar_afip_responsibility_type_id);
+        apply(this.faFields.fa_name, values.name);
+        apply(this.faFields.fa_street, values.street);
+        apply(this.faFields.fa_zip, values.zip);
+        apply(this.faFields.fa_city, values.city);
+        apply(this.faFields.fa_state_id, values.state_id);
+    },
+
+    _isValidCuit(digits) {
+        if (digits.length !== CUIT_LENGTH) {
+            return false;
+        }
+        const weights = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2];
+        const sum = weights.reduce((acc, w, i) => acc + w * parseInt(digits[i], 10), 0);
+        let check = 11 - (sum % 11);
+        if (check === 11) {
+            check = 0;
+        } else if (check === 10) {
+            check = 9;
+        }
+        return check === parseInt(digits[10], 10);
+    },
+
+    // The native interaction re-marks `vat` required for AR on every country change
+    // (after our setup ran). Re-assert our Factura A state so the hidden CUIT is not
+    // left required (which would silently fail form.reportValidity()).
+    async _onChangeCountry(init = false) {
+        await super._onChangeCountry(init);
+        if (this.expressForm && this.vatInput) {
+            this.vatInput.required = this.facturaACheckbox.checked;
+            if (this.facturaACheckbox.checked) {
+                this._onCuitInput();
+            } else {
+                this.vatInput.setCustomValidity('');
+            }
+        }
+    },
+
+    _checkZip() {
+        const value = this.zipInput.value.trim();
+        this.zipInput.setCustomValidity(
+            value.length > 0 && value.length < 4
+                ? 'El código postal debe tener al menos 4 caracteres.'
+                : ''
+        );
+    },
+
+    // ==================================================================
+    // Persistence — keep the provisional partner in sync with the form
+    // ==================================================================
+    // Contact + address + CF document. The CUIT (Factura A) is intentionally not
+    // persisted here: its billing partner is built at submit; when Factura A is on
+    // the main document is left blank.
+    _formPayload() {
+        const val = (name) => this.addressForm.querySelector(`[name="${name}"]`)?.value?.trim() || '';
+        return {
+            name: val('name'),
+            email: val('email'),
+            phone: val('phone'),
+            street: val('street'),
+            city: val('city'),
+            zip: val('zip'),
+            state_id: val('state_id'),
+            vat: this.facturaACheckbox?.checked ? '' : (this.dniInput?.value?.trim() || ''),
+        };
+    },
+
+    async _persistForm() {
+        await this.waitFor(rpc('/shop/express_checkout/save', this._formPayload()));
+    },
+
+    // ==================================================================
+    // Delivery
+    // ==================================================================
+    async _refreshDeliveryMethods() {
+        const payload = this._formPayload();
+        if (payload.zip.replace(/\D/g, '').length < 4 || !payload.state_id) {
+            return;
+        }
+        const res = await this.waitFor(rpc('/shop/express_checkout/delivery_methods', payload));
+        if (res && res.delivery_form) {
+            this.deliveryContainer.innerHTML = res.delivery_form;
+            this._wireDeliveryMethods();
+            await this._rateDeliveryMethods();
+        }
+    },
+
+    _wireDeliveryMethods() {
+        this.deliveryContainer.querySelectorAll('input[name="o_delivery_radio"]').forEach((radio) => {
+            radio.addEventListener('change', () => this._selectDeliveryMethod(radio));
+        });
+    },
+
+    _deliveryBadge(radio) {
+        return radio.closest('[name="o_delivery_method"]')?.querySelector('[name="price"]');
+    },
+
+    async _rateDeliveryMethods() {
+        const radios = this.deliveryContainer.querySelectorAll('input[name="o_delivery_radio"]');
+        await Promise.all([...radios].map(async (radio) => {
+            const badge = this._deliveryBadge(radio);
+            try {
+                const rate = await this.waitFor(rpc('/shop/get_delivery_rate', { dm_id: radio.dataset.dmId }));
+                if (rate && rate.success) {
+                    radio.disabled = false;
+                    if (badge) {
+                        badge.classList.remove('text-muted');
+                        badge.innerHTML = rate.is_free_delivery ? 'Gratis' : (rate.amount_delivery || '');
+                    }
+                } else {
+                    radio.disabled = true;
+                    if (badge) {
+                        badge.classList.add('text-muted');
+                        badge.textContent = (rate && rate.error_message) || '';
+                    }
+                }
+            } catch {
+                radio.disabled = true;
+            }
+        }));
+    },
+
+    async _selectDeliveryMethod(radio) {
+        if (radio.disabled) {
+            return;
+        }
+        const res = await this.waitFor(rpc('/shop/set_delivery_method', { dm_id: radio.dataset.dmId }));
+        const badge = this._deliveryBadge(radio);
+        if (badge && res) {
+            badge.innerHTML = res.is_free_delivery ? 'Gratis' : (res.amount_delivery || '');
+        }
+    },
+});

--- a/website_sale_express_checkout/tests/__init__.py
+++ b/website_sale_express_checkout/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_express_checkout

--- a/website_sale_express_checkout/tests/test_express_checkout.py
+++ b/website_sale_express_checkout/tests/test_express_checkout.py
@@ -1,0 +1,167 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.addons.website_sale.tests.common import MockRequest
+from odoo.addons.website_sale_express_checkout.controllers.main import (
+    WebsiteSaleExpressCheckout,
+)
+from odoo.tests import tagged
+
+DELIVERY_HREF = "/shop/checkout"
+EXTRA_HREF = "/shop/extra_info"
+EXPRESS_HREF = "/shop/express_checkout"
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestExpressCheckout(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ar_company = cls.company_data["company"]
+        cls.website = cls.env["website"].create(
+            {
+                "name": "AR Express Website",
+                "company_id": cls.ar_company.id,
+            }
+        )
+        cls.controller = WebsiteSaleExpressCheckout()
+        cls.res_CF = cls.env.ref("l10n_ar.res_CF")
+        cls.res_IVARI = cls.env.ref("l10n_ar.res_IVARI")
+        cls.res_IVAE = cls.env.ref("l10n_ar.res_IVAE")
+        cls.it_cuit = cls.env.ref("l10n_ar.it_cuit")
+        cls.it_dni = cls.env.ref("l10n_ar.it_dni")
+
+    # ------------------------------------------------------------------
+    # Steps (model level, no request)
+    # ------------------------------------------------------------------
+    def test_steps_disabled_is_standard(self):
+        """Default flag False -> delivery/extra published, express not."""
+        self.assertFalse(self.website.enable_express_checkout)
+        self.assertTrue(self.website._get_checkout_step(DELIVERY_HREF).is_published)
+        self.assertFalse(self.website._get_checkout_step(EXPRESS_HREF).is_published)
+
+    def test_steps_toggle_publishes_express(self):
+        self.website.enable_express_checkout = True
+        self.assertTrue(self.website._get_checkout_step(EXPRESS_HREF).is_published)
+        self.assertFalse(self.website._get_checkout_step(DELIVERY_HREF).is_published)
+        self.assertFalse(self.website._get_checkout_step(EXTRA_HREF).is_published)
+        # Disabling restores the native steps.
+        self.website.enable_express_checkout = False
+        self.assertFalse(self.website._get_checkout_step(EXPRESS_HREF).is_published)
+        self.assertTrue(self.website._get_checkout_step(DELIVERY_HREF).is_published)
+
+    def test_enabling_sets_background_post(self):
+        self.ar_company.website_sale_background_post = False
+        self.website.enable_express_checkout = True
+        self.assertTrue(self.ar_company.website_sale_background_post)
+
+    # ------------------------------------------------------------------
+    # AR-only guard
+    # ------------------------------------------------------------------
+    def test_ar_only_guard(self):
+        self.website.enable_express_checkout = True
+        cart = (
+            self.env["sale.order"]
+            .sudo()
+            .create(
+                {
+                    "partner_id": self.partner.id,
+                    "company_id": self.ar_company.id,
+                    "website_id": self.website.id,
+                }
+            )
+        )
+        self.assertTrue(self.controller._express_checkout_enabled(cart))
+        self.website.enable_express_checkout = False
+        self.assertFalse(self.controller._express_checkout_enabled(cart))
+
+    # ------------------------------------------------------------------
+    # Payload hardening: derived fields are discarded (forged POST, C2)
+    # ------------------------------------------------------------------
+    def test_parse_form_data_discards_derived_fields(self):
+        forged = {
+            "name": "Foo",
+            "email": "foo@example.com",
+            "l10n_ar_afip_responsibility_type_id": str(self.res_IVARI.id),
+            "l10n_latam_identification_type_id": str(self.it_cuit.id),
+        }
+        with MockRequest(self.env, website=self.website) as request:
+            request.express_checkout_flow = True
+            request.express_checkout_factura_a = False
+            address_values, _extra = self.controller._parse_form_data(forged)
+        self.assertNotIn("l10n_ar_afip_responsibility_type_id", address_values)
+        self.assertNotIn("l10n_latam_identification_type_id", address_values)
+        self.assertEqual(address_values.get("name"), "Foo")
+
+    def test_parse_form_data_derives_id_type_from_document(self):
+        # CF: the id type is derived from the document shape (not trusted from the
+        # form) and set alongside the vat — a DNI-length number -> it_dni.
+        with MockRequest(self.env, website=self.website) as request:
+            request.express_checkout_flow = True
+            request.express_checkout_factura_a = False
+            dni_values, _e = self.controller._parse_form_data({"name": "Foo", "vat": "12345678"})
+            cuit_values, _e = self.controller._parse_form_data({"name": "Bar", "vat": "30712345671"})
+        self.assertEqual(dni_values.get("l10n_latam_identification_type_id"), self.it_dni.id)
+        self.assertEqual(cuit_values.get("l10n_latam_identification_type_id"), self.it_cuit.id)
+
+    # ------------------------------------------------------------------
+    # Server-side tax derivation (C6) — via _express_apply_tax_identity
+    # ------------------------------------------------------------------
+    def _apply_identity(self, factura_a=False, vat=False, id_type=None, responsibility=None):
+        vals = {"name": "Comprador"}
+        if id_type:
+            vals["l10n_latam_identification_type_id"] = id_type.id
+        if vat:
+            vals["vat"] = vat
+        if responsibility:
+            vals["l10n_ar_afip_responsibility_type_id"] = responsibility.id
+        partner = self.env["res.partner"].sudo().create(vals)
+        with MockRequest(self.env, website=self.website) as request:
+            request.express_checkout_flow = True
+            request.express_checkout_factura_a = factura_a
+            self.controller._express_apply_tax_identity(partner, factura_a)
+        return partner
+
+    def test_derive_cf_without_document(self):
+        partner = self._apply_identity()
+        self.assertEqual(partner.l10n_ar_afip_responsibility_type_id, self.res_CF)
+        self.assertEqual(partner.l10n_latam_identification_type_id, self.it_dni)
+        self.assertEqual(partner.country_id, self.env.ref("base.ar"))
+
+    def test_derive_cf_with_cuit_shaped_document(self):
+        partner = self._apply_identity(vat="30712345671", id_type=self.it_cuit)
+        self.assertEqual(partner.l10n_latam_identification_type_id, self.it_cuit)
+        self.assertEqual(partner.l10n_ar_afip_responsibility_type_id, self.res_CF)
+
+    def test_factura_a_sets_cuit_keeps_form_responsibility(self):
+        # Factura A: id type is forced to CUIT; the responsibility comes from the
+        # form (here Exento) and is NOT overwritten with a default.
+        partner = self._apply_identity(factura_a=True, responsibility=self.res_IVAE)
+        self.assertEqual(partner.l10n_latam_identification_type_id, self.it_cuit)
+        self.assertEqual(partner.l10n_ar_afip_responsibility_type_id, self.res_IVAE)
+
+    def test_existing_responsibility_not_overwritten(self):
+        # C9: a partner that already is Responsable Inscripto must not be degraded.
+        partner = self._apply_identity(factura_a=False, responsibility=self.res_IVARI)
+        self.assertEqual(partner.l10n_ar_afip_responsibility_type_id, self.res_IVARI)
+
+    def test_complete_address_values_sets_country_no_tax(self):
+        values = {"street": "Av. Siempreviva 742"}
+        cart = (
+            self.env["sale.order"]
+            .sudo()
+            .create(
+                {
+                    "partner_id": self.partner.id,
+                    "company_id": self.ar_company.id,
+                    "website_id": self.website.id,
+                }
+            )
+        )
+        with MockRequest(self.env, website=self.website) as request:
+            request.express_checkout_flow = True
+            self.controller._complete_address_values(values, "delivery", False, order_sudo=cart)
+        self.assertEqual(values["country_id"], self.env.ref("base.ar").id)
+        self.assertNotIn("l10n_ar_afip_responsibility_type_id", values)

--- a/website_sale_express_checkout/views/express_checkout_templates.xml
+++ b/website_sale_express_checkout/views/express_checkout_templates.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Primary field block. Inheriting portal.address_form_fields (not a fresh
+         template) means _get_combined_archs applies every extension of the parent
+         to us too (l10n_ar's ARCA block, l10n_latam, etc.). We render with
+         is_used_as_billing = False, so the whole b2b block AND the ARCA
+         responsibility select/hidden simply do not render (spec §3 / C2). The CUIT
+         for the Factura A path is rendered by the page below, not here. -->
+    <template id="address_form_fields" inherit_id="portal.address_form_fields" primary="True">
+        <!-- AR-only: keep the (hidden) country select so the native interaction
+             still loads AR states, but the buyer never sees or changes it. -->
+        <xpath expr="//div[@id='div_country']" position="attributes">
+            <attribute name="class" add="d-none" separator=" "/>
+        </xpath>
+        <!-- street2 behind a collapsed disclosure. -->
+        <xpath expr="//div[@id='div_street2']" position="before">
+            <div class="col-lg-12 mb-1">
+                <a
+                    role="button"
+                    class="small text-decoration-none"
+                    data-bs-toggle="collapse"
+                    href="#div_street2"
+                >
+                    <i class="fa fa-plus me-1"/>Agregar piso, depto o indicaciones
+                </a>
+            </div>
+        </xpath>
+        <xpath expr="//div[@id='div_street2']" position="attributes">
+            <attribute name="class">col-lg-12 mb-2 collapse</attribute>
+        </xpath>
+    </template>
+
+    <!-- /shop/express_checkout page -->
+    <template id="express_checkout" name="Express Checkout AR">
+        <t t-call="website_sale.checkout_layout">
+            <t t-set="additional_title">Shop - Checkout</t>
+            <t t-set="redirect" t-valuef="/shop/express_checkout"/>
+            <div class="o_customer_address_fill">
+                <div id="errors"/> <!-- for js -->
+                <form
+                    action="/shop/express_checkout/submit"
+                    method="post"
+                    name="address_form"
+                    class="address_autoformat o_express_checkout_form"
+                    t-att-data-company-country-code="res_company.country_id.code"
+                    data-submit-url="/shop/express_checkout/submit"
+                >
+                    <h4 class="mb-3">Datos de contacto y entrega</h4>
+                    <div name="address_details" class="row">
+                        <t t-call="website_sale_express_checkout.address_form_fields"/>
+                        <!-- Consumidor Final document. Shares name="vat" with the
+                             Factura A CUIT input; the JS disables whichever one is
+                             inactive so only one is submitted. -->
+                        <div class="col-lg-6 mb-2" id="div_express_dni">
+                            <label class="col-form-label" for="express_dni">DNI</label>
+                            <input
+                                type="text"
+                                id="express_dni"
+                                name="vat"
+                                class="form-control"
+                                inputmode="numeric"
+                                autocomplete="off"
+                                required="required"
+                                t-att-value="partner_sudo.vat"
+                            />
+                        </div>
+                    </div>
+
+                    <!-- Factura A: CUIT + fiscal fields filled from ARCA (readonly)
+                         or entered by hand when ARCA can't be reached. -->
+                    <div class="o_express_factura_a border-top pt-3 mt-2">
+                        <div class="form-check">
+                            <input
+                                type="checkbox"
+                                id="express_factura_a"
+                                name="factura_a"
+                                value="true"
+                                class="form-check-input"
+                                t-att-checked="express_factura_a"
+                            />
+                            <label class="form-check-label" for="express_factura_a">
+                                Necesito factura a nombre de mi empresa o monotributo
+                            </label>
+                        </div>
+                        <div id="express_factura_a_fields" t-attf-class="mt-2 #{'' if express_factura_a else 'd-none'}">
+                            <div class="row">
+                                <div class="col-lg-6 mb-2">
+                                    <label class="col-form-label" for="express_vat">CUIT</label>
+                                    <div class="input-group">
+                                        <input
+                                            type="text"
+                                            id="express_vat"
+                                            name="vat"
+                                            class="form-control"
+                                            inputmode="numeric"
+                                            autocomplete="off"
+                                            t-att-value="express_fa_billing.vat"
+                                        />
+                                        <span class="input-group-text d-none" id="express_vat_status"/>
+                                    </div>
+                                    <small id="express_vat_msg" class="form-text text-danger d-none">
+                                        El CUIT ingresado no es válido.
+                                    </small>
+                                </div>
+                            </div>
+                            <!-- Fiscal details: shown once the CUIT resolves — readonly
+                                 if ARCA answered, editable if it could not be reached. -->
+                            <div id="express_fa_details" t-attf-class="row #{'' if express_factura_a else 'd-none'}">
+                                <div class="col-lg-6 mb-2">
+                                    <label class="col-form-label" for="express_fa_responsibility">
+                                        Responsabilidad ARCA
+                                    </label>
+                                    <select
+                                        id="express_fa_responsibility"
+                                        name="fa_responsibility"
+                                        class="form-select"
+                                    >
+                                        <option value="">Seleccioná...</option>
+                                        <option
+                                            t-foreach="express_responsibility_types"
+                                            t-as="rt"
+                                            t-att-value="rt.id"
+                                            t-att-selected="rt == express_fa_billing.l10n_ar_afip_responsibility_type_id"
+                                            t-out="rt.name"
+                                        />
+                                    </select>
+                                </div>
+                                <div class="col-lg-6 mb-2">
+                                    <label class="col-form-label" for="express_fa_name">Razón social</label>
+                                    <input type="text" id="express_fa_name" name="fa_name" class="form-control" t-att-value="express_fa_billing.name"/>
+                                </div>
+                                <div class="col-lg-12 mb-2">
+                                    <label class="col-form-label" for="express_fa_street">
+                                        Domicilio fiscal
+                                    </label>
+                                    <input
+                                        type="text"
+                                        id="express_fa_street"
+                                        name="fa_street"
+                                        class="form-control"
+                                        placeholder="Calle y número"
+                                        t-att-value="express_fa_billing.street"
+                                    />
+                                </div>
+                                <div class="col-md-4 mb-2">
+                                    <label class="col-form-label" for="express_fa_zip">Código postal</label>
+                                    <input type="text" id="express_fa_zip" name="fa_zip" class="form-control" t-att-value="express_fa_billing.zip"/>
+                                </div>
+                                <div class="col-md-8 mb-2">
+                                    <label class="col-form-label" for="express_fa_city">Ciudad</label>
+                                    <input type="text" id="express_fa_city" name="fa_city" class="form-control" t-att-value="express_fa_billing.city"/>
+                                </div>
+                                <div class="col-lg-6 mb-2">
+                                    <label class="col-form-label" for="express_fa_state">Provincia</label>
+                                    <select id="express_fa_state" name="fa_state_id" class="form-select">
+                                        <option value="">Provincia...</option>
+                                        <option
+                                            t-foreach="country_states"
+                                            t-as="s"
+                                            t-att-value="s.id"
+                                            t-att-selected="s == express_fa_billing.state_id"
+                                            t-out="s.name"
+                                        />
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Delivery method. The express interaction re-renders this
+                         container (and enables selection) once the delivery address
+                         is complete, so the carriers can be rated for that address. -->
+                    <div
+                        t-if="order._has_deliverable_products()"
+                        id="express_delivery_container"
+                        class="mb-4 mt-4"
+                    >
+                        <t t-call="website_sale.delivery_form">
+                            <t t-set="selected_dm_id" t-value="order.carrier_id.id"/>
+                        </t>
+                    </div>
+                </form>
+            </div>
+        </t>
+    </template>
+
+</odoo>

--- a/website_sale_express_checkout/views/res_config_settings_views.xml
+++ b/website_sale_express_checkout/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.website_sale_express_checkout</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <setting id="checkout_registration_setting" position="after">
+                <setting
+                    id="enable_express_checkout_setting"
+                    string="Express Checkout (AR)"
+                    help="One-page checkout for Argentinean stores: fewer fields, no tax decisions asked to the buyer, everything derived server-side. Only affects carts whose company is Argentinean.">
+                    <field name="enable_express_checkout"/>
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_express_checkout_padron/README.rst
+++ b/website_sale_express_checkout_padron/README.rst
@@ -1,0 +1,69 @@
+======================================================
+Website Sale Express Checkout AR - ARCA Padron Bridge
+======================================================
+
+Completa el partner de facturación del camino Factura A con los datos del padrón
+de ARCA durante el express checkout.
+
+Características
+===============
+
+- Cuando el comprador pide Factura A, consulta el padrón de ARCA en el submit y
+  aplica al partner de facturación la razón social, el domicilio fiscal y la
+  Responsabilidad ARCA que devuelva el padrón.
+- La consulta tiene un timeout configurable (parámetro de sistema, 8 segundos por
+  defecto); superado el tiempo, se conserva el default.
+- Cualquier falla de la consulta (sin certificado, timeout, error del web
+  service, CUIT ausente del padrón) se absorbe y se conserva la responsabilidad
+  por defecto ya fijada por el módulo base, de modo que la compra se completa y la
+  factura se emite igual (en background).
+- Bridge de instalación automática: se instala solo cuando conviven el express
+  checkout y la facturación electrónica argentina.
+
+Detalles Técnicos
+=================
+
+Controlador
+-----------
+
+- ``WebsiteSaleExpressCheckout`` — override de ``_express_apply_padron``: llama a
+  ``res.partner.get_data_from_padron_afip()``, limita el tiempo a nivel socket,
+  captura cualquier excepción para conservar el default y escribe sobre el partner
+  de facturación únicamente los campos fiscales (``name``, ``street``, ``city``,
+  ``zip``, ``state_id``, ``l10n_ar_afip_responsibility_type_id``).
+
+Parámetros de sistema
+---------------------
+
+- ``website_sale_express_checkout.padron_timeout`` — timeout de la consulta en
+  segundos (default ``8``).
+
+Uso
+===
+
+No requiere configuración: se instala automáticamente cuando están presentes
+``website_sale_express_checkout`` y ``l10n_ar_edi_ux``, y actúa solo en el camino
+Factura A del express checkout.
+
+Arquitectura
+============
+
+Vive separado del módulo base porque ``l10n_ar_edi_ux`` es Enterprise y depende de
+``account_accountant``: el módulo base no puede depender de eso. El bridge implementa
+el hook ``_express_apply_padron`` que el base deja vacío.
+
+Dependencias
+============
+
+- ``website_sale_express_checkout``
+- ``l10n_ar_edi_ux``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/website_sale_express_checkout_padron/__init__.py
+++ b/website_sale_express_checkout_padron/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import controllers

--- a/website_sale_express_checkout_padron/__manifest__.py
+++ b/website_sale_express_checkout_padron/__manifest__.py
@@ -1,0 +1,36 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Website Sale Express Checkout AR - ARCA Padron Bridge",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "category": "Website/Website",
+    "summary": "Fills the Factura A billing partner from the ARCA padron on express checkout",
+    "depends": [
+        "website_sale_express_checkout",
+        "l10n_ar_edi_ux",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/website_sale_express_checkout_padron/controllers/__init__.py
+++ b/website_sale_express_checkout_padron/controllers/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import main

--- a/website_sale_express_checkout_padron/controllers/main.py
+++ b/website_sale_express_checkout_padron/controllers/main.py
@@ -1,0 +1,98 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import logging
+import socket
+
+from odoo.addons.website_sale_express_checkout.controllers.main import (
+    WebsiteSaleExpressCheckout,
+)
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+# Keys of get_data_from_padron_afip()'s dict that we surface to the checkout.
+_PADRON_FISCAL_FIELDS = (
+    "name",
+    "street",
+    "city",
+    "zip",
+    "state_id",
+    "l10n_ar_afip_responsibility_type_id",
+)
+
+_PADRON_TIMEOUT_PARAM = "website_sale_express_checkout.padron_timeout"
+_DEFAULT_PADRON_TIMEOUT = 8.0
+_CUIT_LENGTH = 11
+
+
+class _PadronRollback(Exception):
+    """Sentinel raised to force the lookup savepoint to roll back."""
+
+
+class WebsiteSaleExpressCheckout(WebsiteSaleExpressCheckout):
+    def _express_padron_lookup(self, vat=None):
+        """Run the real ARCA padron query for a CUIT.
+
+        Returns ``{"available": True, "found": True, "values": {...}}`` with the
+        (possibly incomplete) fiscal fields ARCA returned, or ``{"available": True,
+        "found": False}`` on any failure (missing certificate, WS timeout/error,
+        CUIT absent from the padron) so the client lets the buyer fill the fields by
+        hand. The client locks the returned fields and keeps the empty ones editable.
+        """
+        digits = "".join(ch for ch in (vat or "") if ch.isdigit())
+        if len(digits) != _CUIT_LENGTH:
+            return {"available": True, "found": False}
+
+        env = request.env
+        values = {}
+        previous_timeout = socket.getdefaulttimeout()
+        try:
+            # The WS client does not expose a timeout, so we cap it at the socket
+            # layer (best-effort); a hang surfaces as an exception caught below.
+            socket.setdefaulttimeout(self._express_padron_timeout())
+            # get_data_from_padron_afip has persistence side-effects (it creates
+            # missing activity/tax records and, for real-estate/consorcio CUITs,
+            # calls message_post on the partner — which fails on an in-memory NewId
+            # record). Run it on a real partner inside a savepoint we always roll
+            # back: nothing persists, but the method behaves exactly as it does
+            # from the native "update from padron" wizard.
+            with env.cr.savepoint():
+                partner = (
+                    env["res.partner"]
+                    .sudo()
+                    .create(
+                        {
+                            "name": "ARCA padron lookup",
+                            "l10n_latam_identification_type_id": env.ref("l10n_ar.it_cuit").id,
+                            "vat": digits,
+                        }
+                    )
+                )
+                values = partner.get_data_from_padron_afip()
+                raise _PadronRollback()
+        except _PadronRollback:
+            pass  # values captured above; the savepoint has been rolled back
+        except Exception as error:  # noqa: BLE001 - any failure -> manual entry
+            _logger.warning("Express checkout: ARCA padron lookup failed for %s: %s", digits, error)
+            return {"available": True, "found": False}
+        finally:
+            socket.setdefaulttimeout(previous_timeout)
+
+        fiscal = {key: values[key] for key in _PADRON_FISCAL_FIELDS if values.get(key)}
+        if fiscal:
+            # ARCA answered with fiscal data (possibly incomplete: it may omit the
+            # responsibility for some real-estate/special CUITs, or the city). The
+            # client locks the fields ARCA returned and leaves the empty ones
+            # editable, so a missing value never blocks the checkout.
+            return {"available": True, "found": True, "values": fiscal}
+        # ARCA did not answer with usable data -> fully manual entry.
+        return {"available": True, "found": False}
+
+    def _express_padron_timeout(self):
+        raw = request.env["ir.config_parameter"].sudo().get_param(_PADRON_TIMEOUT_PARAM)
+        try:
+            return float(raw) if raw else _DEFAULT_PADRON_TIMEOUT
+        except (TypeError, ValueError):
+            return _DEFAULT_PADRON_TIMEOUT

--- a/website_sale_express_checkout_padron/tests/__init__.py
+++ b/website_sale_express_checkout_padron/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_padron

--- a/website_sale_express_checkout_padron/tests/test_padron.py
+++ b/website_sale_express_checkout_padron/tests/test_padron.py
@@ -1,0 +1,93 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from unittest.mock import patch
+
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.addons.website_sale.tests.common import MockRequest
+from odoo.addons.website_sale_express_checkout_padron.controllers.main import (
+    WebsiteSaleExpressCheckout as PadronController,
+)
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+_PADRON_METHOD = "get_data_from_padron_afip"
+_PADRON_LOGGER = "odoo.addons.website_sale_express_checkout_padron.controllers.main"
+# A valid CUIT (check digit) so the endpoint runs the query instead of bailing out.
+_VALID_CUIT = "30712345671"
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestExpressCheckoutPadronLookup(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env["website"].create(
+            {
+                "name": "AR Padron Website",
+                "company_id": cls.company_data["company"].id,
+            }
+        )
+        cls.controller = PadronController()
+        cls.res_RM = cls.env.ref("l10n_ar.res_RM")
+
+    def _lookup(self, vat):
+        with MockRequest(self.env, website=self.website):
+            return self.controller._express_padron_lookup(vat=vat)
+
+    def test_lookup_success(self):
+        padron = {
+            "name": "ACME SA",
+            "street": "Av. Corrientes 1234",
+            "city": "CABA",
+            "zip": "C1043",
+            "l10n_ar_afip_responsibility_type_id": self.res_RM.id,
+        }
+        with patch.object(self.registry["res.partner"], _PADRON_METHOD, return_value=padron):
+            res = self._lookup(_VALID_CUIT)
+        self.assertTrue(res["available"])
+        self.assertTrue(res["found"])
+        self.assertEqual(res["values"]["l10n_ar_afip_responsibility_type_id"], self.res_RM.id)
+        self.assertEqual(res["values"]["name"], "ACME SA")
+
+    @mute_logger(_PADRON_LOGGER)
+    def test_lookup_usererror_is_manual(self):
+        with patch.object(self.registry["res.partner"], _PADRON_METHOD, side_effect=UserError("no certificate")):
+            res = self._lookup(_VALID_CUIT)
+        self.assertTrue(res["available"])
+        self.assertFalse(res["found"])
+
+    @mute_logger(_PADRON_LOGGER)
+    def test_lookup_timeout_is_manual(self):
+        with patch.object(self.registry["res.partner"], _PADRON_METHOD, side_effect=TimeoutError("ws timeout")):
+            res = self._lookup(_VALID_CUIT)
+        self.assertFalse(res["found"])
+
+    def test_lookup_partial_returns_found_with_values(self):
+        # ARCA answered with fiscal data but no responsibility: still found=True,
+        # with the values it did return. The client locks those and leaves the
+        # empty fields (e.g. the responsibility) editable — never blocked.
+        with patch.object(
+            self.registry["res.partner"],
+            _PADRON_METHOD,
+            return_value={"name": "ACME", "street": "Av. Corrientes 1234"},
+        ):
+            res = self._lookup(_VALID_CUIT)
+        self.assertTrue(res["found"])
+        self.assertEqual(res["values"]["name"], "ACME")
+        self.assertNotIn("l10n_ar_afip_responsibility_type_id", res["values"])
+
+    def test_lookup_invalid_cuit_does_not_query(self):
+        with patch.object(self.registry["res.partner"], _PADRON_METHOD) as mocked:
+            res = self._lookup("123")
+            mocked.assert_not_called()
+        self.assertFalse(res["found"])
+
+    def test_timeout_param_default(self):
+        with MockRequest(self.env, website=self.website):
+            self.assertEqual(self.controller._express_padron_timeout(), 8.0)
+        self.env["ir.config_parameter"].sudo().set_param("website_sale_express_checkout.padron_timeout", "3.5")
+        with MockRequest(self.env, website=self.website):
+            self.assertEqual(self.controller._express_padron_timeout(), 3.5)


### PR DESCRIPTION
## What

Two new modules for a single-page checkout in Argentinean eCommerce stores:

- **`website_sale_express_checkout`** — collapses the checkout into one step (`cart` → `express_checkout` → `payment`), unpublishing the native delivery/extra-info steps. AR-only (checked on the cart's company) and opt-in per website via a setting. The ARCA responsibility and identification type are derived server-side; the buyer takes no tax decision. Derived tax fields are neither rendered nor accepted from the payload (a forged POST cannot set them).
- **`website_sale_express_checkout_padron`** — `auto_install` bridge with `l10n_ar_edi_ux`. On the Factura A path it queries the ARCA padron on submit and fills the billing partner (razón social, fiscal domicile, responsibility), with a configurable timeout and a fallback that keeps the sale completing (default Responsable Inscripto, invoice posted in background) when ARCA is unavailable.

## Approach

Reuses the native `portal`/`website_sale` address hooks (`_create_or_update_address`, `_parse_form_data`, `_complete_address_values`, `_get_mandatory_billing_address_fields`) instead of forking controllers or templates, so the localization extensions keep working. The field template is a primary view inheriting `portal.address_form_fields`. Checkout steps are reconfigured declaratively via `website.checkout.step` publication (per website), with no override of the navigation engine.

## Test plan

- Unit/integration tests included (`tests/`): step publication on the setting toggle, background-post activation, server-side tax derivation for the four paths, forged-POST hardening, and the padron application/fallback modes (ARCA resolves / UserError / timeout / no Factura A).
- Manual on runbot: enable the setting on an AR website; complete a purchase as Consumidor Final and as Factura A; verify the checkout is one page, the 7 visible fields, and that a forged responsibility in the POST is discarded.

Spec: `website-sale-express-checkout` (oba-project, ecommerce).
Task: https://www.adhoc.inc/odoo/project.task/70982