### PR TITLE
[IMP] facebook_pixel_tracking: send Purchase server-side via Meta CAPI

### DIFF
--- a/facebook_pixel_tracking/__init__.py
+++ b/facebook_pixel_tracking/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import controllers

--- a/facebook_pixel_tracking/__manifest__.py
+++ b/facebook_pixel_tracking/__manifest__.py
@@ -28,6 +28,7 @@
         "website_sale_advanced_tracking",
     ],
     "data": [
+        "data/ir_cron.xml",
         "views/res_config_settings_view.xml",
         "views/website_templates.xml",
     ],

--- a/facebook_pixel_tracking/controllers/__init__.py
+++ b/facebook_pixel_tracking/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/facebook_pixel_tracking/controllers/main.py
+++ b/facebook_pixel_tracking/controllers/main.py
@@ -1,0 +1,53 @@
+import logging
+
+from odoo import http
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+_logger = logging.getLogger(__name__)
+
+
+class FacebookCapiWebsiteSale(WebsiteSale):
+    @http.route()
+    def shop_checkout(self, try_skip_step=None, **query_params):
+        """Override to capture Meta browser identifiers into the sale order.
+
+        The purchase event is sent server-side at confirmation, which may
+        arrive via a payment gateway webhook with no browser request. So the
+        fbp/fbc/ip/user-agent/url are captured here, while the browser is
+        still present, and persisted on the order.
+        """
+        order = http.request.cart
+        if order:
+            try:
+                httprequest = http.request.httprequest
+                cookies = httprequest.cookies
+
+                # Fill each field only when still empty, so identifiers that
+                # were not available on an earlier checkout render (e.g. the
+                # _fbp cookie set later, or the pixel briefly blocked) are
+                # captured on a subsequent render instead of frozen by a single
+                # sentinel.
+                vals = {}
+                if not order.fb_fbp and cookies.get("_fbp"):
+                    vals["fb_fbp"] = cookies.get("_fbp")
+                if not order.fb_fbc:
+                    fbc = cookies.get("_fbc")
+                    if not fbc:
+                        fbclid = query_params.get("fbclid")
+                        if fbclid:
+                            fbc = order._build_fbc_from_fbclid(fbclid)
+                    if fbc:
+                        vals["fb_fbc"] = fbc
+                if not order.fb_client_ip_address and httprequest.remote_addr:
+                    vals["fb_client_ip_address"] = httprequest.remote_addr
+                if not order.fb_client_user_agent and httprequest.user_agent:
+                    vals["fb_client_user_agent"] = httprequest.user_agent.string
+                if not order.fb_event_source_url and httprequest.url:
+                    vals["fb_event_source_url"] = httprequest.url
+
+                if vals:
+                    order.sudo().write(vals)
+            except Exception as exc:
+                _logger.warning("Facebook CAPI: failed to capture browser data: %s", exc)
+
+        return super().shop_checkout(try_skip_step=try_skip_step, **query_params)

--- a/facebook_pixel_tracking/data/ir_cron.xml
+++ b/facebook_pixel_tracking/data/ir_cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="cron_retry_facebook_capi_events" model="ir.cron">
+        <field name="name">Facebook CAPI: Retry Failed Conversions API Events</field>
+        <field name="active">True</field>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">15</field>
+        <field name="interval_type">minutes</field>
+        <field name="model_id" ref="website.model_website"/>
+        <field name="state">code</field>
+        <field name="code">env['website'].sudo()._retry_failed_facebook_capi_events()</field>
+    </record>
+</odoo>

--- a/facebook_pixel_tracking/models/__init__.py
+++ b/facebook_pixel_tracking/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_config_settings
 from . import website
+from . import sale_order

--- a/facebook_pixel_tracking/models/res_config_settings.py
+++ b/facebook_pixel_tracking/models/res_config_settings.py
@@ -5,3 +5,9 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     facebook_pixel_key = fields.Char("Facebook pixel ID", related="website_id.facebook_pixel_key", readonly=False)
+    facebook_capi_access_token = fields.Char(
+        string="Facebook CAPI Access Token",
+        related="website_id.facebook_capi_access_token",
+        readonly=False,
+        groups="base.group_system",
+    )

--- a/facebook_pixel_tracking/models/sale_order.py
+++ b/facebook_pixel_tracking/models/sale_order.py
@@ -1,0 +1,342 @@
+import hashlib
+import json
+import logging
+import time
+from functools import partial
+
+import requests
+from odoo import SUPERUSER_ID, api, fields, models
+from odoo.modules.registry import Registry
+
+_logger = logging.getLogger(__name__)
+
+FACEBOOK_CAPI_ENDPOINT = "https://graph.facebook.com"
+FACEBOOK_GRAPH_VERSION = "v23.0"
+FACEBOOK_CAPI_TIMEOUT = 3  # seconds – must not block payment flow
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    fb_fbp = fields.Char(
+        string="Facebook Browser ID (fbp)",
+        help="Raw _fbp browser cookie captured at checkout start.",
+        copy=False,
+    )
+    fb_fbc = fields.Char(
+        string="Facebook Click ID (fbc)",
+        help="Raw _fbc browser cookie (or built from the fbclid URL param) captured at checkout start.",
+        copy=False,
+    )
+    fb_client_ip_address = fields.Char(
+        string="Facebook Client IP",
+        help="Client IP captured at checkout start (required by Meta for web events).",
+        copy=False,
+    )
+    fb_client_user_agent = fields.Char(
+        string="Facebook Client User Agent",
+        help="Client user-agent captured at checkout start (required by Meta for web events).",
+        copy=False,
+    )
+    fb_event_source_url = fields.Char(
+        string="Facebook Event Source URL",
+        help="Checkout URL captured at checkout start (required by Meta for web events).",
+        copy=False,
+    )
+    facebook_capi_pending_payload = fields.Json(
+        string="Facebook CAPI Pending Payload",
+        help="Stores a failed Conversions API payload for retry by the scheduled action.",
+        copy=False,
+    )
+    facebook_capi_purchase_sent = fields.Boolean(
+        string="Facebook CAPI Purchase Sent",
+        help="Set once the server-side Purchase event has been accepted by Meta, "
+        "so a cancel + re-confirm does not report the same order twice.",
+        copy=False,
+    )
+
+    # ------------------------------------------------------------------
+    # Payload builders
+    # ------------------------------------------------------------------
+
+    def _prepare_facebook_capi_custom_data(self):
+        """Return a Meta CAPI ``custom_data`` dict for this order.
+
+        Built directly from the order lines – not from the shared
+        ``prepare_purchase_information`` helper, whose return type varies by
+        which tracking modules are installed (``website_sale_advanced_tracking``
+        returns a JSON string, ``website_sale_google_analytics_4`` overrides the
+        same method returning a dict). All ``content_ids``/``id`` are emitted as
+        strings: if the browser sends ``['1234']`` and the server ``[1234]``
+        Meta treats the events as different and deduplication breaks silently.
+        """
+        self.ensure_one()
+        contents = []
+        content_ids = []
+        for line in self.order_line:
+            if getattr(line, "is_delivery", False) or getattr(line, "is_reward_line", False):
+                continue
+            item_id = str(line.product_id.default_code or line.product_id.id)
+            content_ids.append(item_id)
+            contents.append(
+                {
+                    "id": item_id,
+                    "quantity": line.product_uom_qty,
+                    "item_price": line.price_reduce_taxinc,
+                }
+            )
+        return {
+            "value": self.amount_total,
+            "currency": self.currency_id.name,
+            "content_type": "product",
+            "content_ids": content_ids,
+            "contents": contents,
+            "order_id": str(self.id),
+        }
+
+    def _prepare_facebook_capi_user_data(self):
+        """Build the Meta CAPI ``user_data`` dict from the order partner.
+
+        Personal identifiers are SHA-256 hashed over their normalized
+        (lowercase + trim) value; browser signals (fbp/fbc/ip/user agent)
+        are sent raw. Empty values are omitted, never sent blank.
+        """
+        self.ensure_one()
+        user_data = {}
+
+        def add_hashed(key, value):
+            hashed = self._facebook_hash(value)
+            if hashed:
+                user_data[key] = hashed
+
+        partner = self.partner_id
+        if partner:
+            add_hashed("em", partner.email)
+            add_hashed("ph", self._facebook_normalize_phone(partner.phone))
+            # Only split first/last name for individuals; a company name hashed
+            # as fn/ln would send misleading person-shaped signals to Meta.
+            if not partner.is_company:
+                name = (partner.name or "").strip()
+                if name:
+                    parts = name.split(" ", 1)
+                    add_hashed("fn", parts[0])
+                    if len(parts) > 1:
+                        add_hashed("ln", parts[1])
+            add_hashed("ct", partner.city)
+            if partner.state_id:
+                add_hashed("st", partner.state_id.code or partner.state_id.name)
+            add_hashed("zp", partner.zip)
+            if partner.country_id:
+                add_hashed("country", partner.country_id.code)
+            add_hashed("external_id", str(partner.id))
+
+        if self.fb_fbp:
+            user_data["fbp"] = self.fb_fbp
+        if self.fb_fbc:
+            user_data["fbc"] = self.fb_fbc
+        if self.fb_client_ip_address:
+            user_data["client_ip_address"] = self.fb_client_ip_address
+        if self.fb_client_user_agent:
+            user_data["client_user_agent"] = self.fb_client_user_agent
+        return user_data
+
+    # ------------------------------------------------------------------
+    # Conversions API
+    # ------------------------------------------------------------------
+
+    def _send_facebook_capi_event(self, event_name, custom_data, _is_retry=False, event_time=None):
+        """Send a single event to the Meta Conversions API.
+
+        Returns True on success, False on failure. On failure the payload is
+        persisted in ``facebook_capi_pending_payload`` for later retry by the
+        cron (unless this call IS the retry). ``event_time`` is preserved
+        across retries so the cron can discard events older than 7 days.
+        """
+        self.ensure_one()
+        # Only website (ecommerce) orders emit a "website" Purchase; skip
+        # backend/manual/subscription orders so they don't inflate reporting.
+        if not self.website_id:
+            if _is_retry:
+                self._facebook_capi_bump_retry_attempts()
+            return False
+        # Meta rejects action_source="website" events without a user agent.
+        # Only send when browser identity was captured at checkout (mirrors the
+        # ga_client_id guard of website_sale_google_analytics_4); this avoids a
+        # guaranteed HTTP 400 (and endless retries) for orders that skipped the
+        # checkout page, e.g. express checkout.
+        if not self.fb_client_user_agent:
+            if _is_retry:
+                self._facebook_capi_bump_retry_attempts()
+            return False
+        website = self.website_id.sudo()
+        pixel_id = website.facebook_pixel_key
+        access_token = website.facebook_capi_access_token
+
+        if not pixel_id or not access_token:
+            if _is_retry:
+                self._facebook_capi_bump_retry_attempts()
+            return False
+
+        if event_time is None:
+            event_time = int(time.time())
+
+        # The whole build + HTTP is inside the try so this method never raises:
+        # a bad partner value (user_data hashing, json.dumps) must persist a
+        # pending payload like any other failure, not propagate out and abort a
+        # batch caller (the retry cron loop has no per-order guard of its own).
+        try:
+            event = {
+                "event_name": event_name,
+                "event_time": event_time,
+                "action_source": "website",
+                "event_id": str(self.id),
+                "user_data": self._prepare_facebook_capi_user_data(),
+                "custom_data": custom_data,
+            }
+            if self.fb_event_source_url:
+                event["event_source_url"] = self.fb_event_source_url
+
+            # access_token travels in the request body (not the URL query string)
+            # so the secret can never leak via the URL into proxy or access logs.
+            form_data = {"data": json.dumps([event]), "access_token": access_token}
+            test_event_code = (
+                self.env["ir.config_parameter"].sudo().get_param("facebook_pixel_tracking.test_event_code")
+            )
+            if test_event_code:
+                form_data["test_event_code"] = test_event_code
+
+            url = "%s/%s/%s/events" % (FACEBOOK_CAPI_ENDPOINT, FACEBOOK_GRAPH_VERSION, pixel_id)
+            response = requests.post(url, data=form_data, timeout=FACEBOOK_CAPI_TIMEOUT)
+            response.raise_for_status()
+            _logger.info(
+                "Facebook CAPI event '%s' sent for order %s",
+                event_name,
+                self.name,
+            )
+            # A previous attempt may have queued this order for retry; clear it.
+            if self.facebook_capi_pending_payload:
+                self.facebook_capi_pending_payload = False
+            if event_name == "Purchase":
+                self.facebook_capi_purchase_sent = True
+            return True
+        except Exception as exc:
+            # Log a sanitized detail (status + Meta error body), never ``exc``
+            # or the URL, as an extra guard around the secret token.
+            error_response = getattr(exc, "response", None)
+            if error_response is not None:
+                detail = "HTTP %s: %s" % (error_response.status_code, (error_response.text or "")[:200])
+            else:
+                detail = type(exc).__name__
+            _logger.warning(
+                "Facebook CAPI event '%s' failed for order %s: %s",
+                event_name,
+                self.name,
+                detail,
+            )
+            if not _is_retry:
+                attempts = (self.facebook_capi_pending_payload or {}).get("_attempts", 0)
+                self.facebook_capi_pending_payload = {
+                    "event_name": event_name,
+                    "custom_data": custom_data,
+                    "event_time": event_time,
+                    "_attempts": attempts + 1,
+                }
+            else:
+                self._facebook_capi_bump_retry_attempts()
+            return False
+
+    def _facebook_capi_bump_retry_attempts(self):
+        """Increment the retry counter on the pending payload.
+
+        Called on any failed retry (including config now missing) so a
+        permanently unsendable order still converges to max_attempts and gets
+        discarded by the cron, instead of being retried forever. Only invoked
+        on the retry path, where a pending payload already exists.
+        """
+        self.ensure_one()
+        payload = dict(self.facebook_capi_pending_payload or {})
+        payload["_attempts"] = payload.get("_attempts", 0) + 1
+        self.facebook_capi_pending_payload = payload
+
+    # ------------------------------------------------------------------
+    # Confirmation hook – server-side purchase event
+    # ------------------------------------------------------------------
+
+    def _action_confirm(self):
+        """Queue a server-side Purchase event to Meta after confirmation.
+
+        The actual HTTP call is deferred to a post-commit hook so that (a) a
+        rolled-back confirmation never reports a phantom Purchase, and (b) the
+        external call never holds row locks on ``sale.order`` while a batch of
+        orders is being confirmed. Covers both the synchronous confirmation and
+        the one that arrives via a payment gateway webhook (no browser request).
+        """
+        res = super()._action_confirm()
+        # Skip orders already sent, and orders that still have a queued payload
+        # (the retry cron owns those) so a cancel + re-confirm does not double-send.
+        orders = self.filtered(
+            lambda o: o.website_id
+            and o.fb_client_user_agent
+            and not o.facebook_capi_purchase_sent
+            and not o.facebook_capi_pending_payload
+        )
+        if orders:
+            self.env.cr.postcommit.add(partial(self._facebook_capi_send_purchase_postcommit, orders.ids))
+        return res
+
+    def _facebook_capi_send_purchase_postcommit(self, order_ids):
+        """Send the queued Purchase event(s) after the confirmation commits.
+
+        Runs in a fresh cursor because the original transaction is already
+        committed by the time post-commit callbacks fire.
+        """
+        dbname = self.env.cr.dbname
+        # Fresh cursor because the confirmation transaction is already committed
+        # by the time post-commit callbacks fire (the context manager commits on
+        # clean exit, so the pending-payload / sent-flag writes persist). As
+        # SUPERUSER because website checkouts confirm as the public/portal user,
+        # which cannot read the order or its partner.
+        with Registry(dbname).cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            for order in env["sale.order"].browse(order_ids).exists():
+                try:
+                    order._send_facebook_capi_event("Purchase", order._prepare_facebook_capi_custom_data())
+                except Exception as exc:
+                    _logger.warning(
+                        "Facebook CAPI purchase event skipped for order %s: %s",
+                        order.id,
+                        exc,
+                    )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @api.model
+    def _facebook_hash(self, value):
+        """Return the SHA-256 hex digest of the normalized value, or ''."""
+        if not value:
+            return ""
+        normalized = str(value).strip().lower()
+        if not normalized:
+            return ""
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+    @api.model
+    def _facebook_normalize_phone(self, phone):
+        """Keep only digits (Meta expects the number with country code, no symbols)."""
+        if not phone:
+            return ""
+        return "".join(ch for ch in phone if ch.isdigit())
+
+    @api.model
+    def _build_fbc_from_fbclid(self, fbclid, creation_time_ms=None):
+        """Build an fbc value from an ``fbclid`` URL param (Meta documented format).
+
+        Format: ``fb.1.<creation_time_ms>.<fbclid>``.
+        """
+        if not fbclid:
+            return ""
+        if creation_time_ms is None:
+            creation_time_ms = int(time.time() * 1000)
+        return "fb.1.%s.%s" % (creation_time_ms, fbclid)

--- a/facebook_pixel_tracking/models/website.py
+++ b/facebook_pixel_tracking/models/website.py
@@ -1,7 +1,54 @@
+import time
+
 from odoo import fields, models
+
+# Meta rejects a whole request if any event is older than 7 days.
+FACEBOOK_CAPI_MAX_EVENT_AGE_DAYS = 7
 
 
 class Website(models.Model):
     _inherit = "website"
 
     facebook_pixel_key = fields.Char("Facebook pixel ID")
+    facebook_capi_access_token = fields.Char(
+        string="Facebook CAPI Access Token",
+        groups="base.group_system",
+        help=(
+            "Conversions API access token used to send server-side events.\n"
+            "Generate one at: Events Manager → your Pixel → Settings → "
+            "Conversions API → Generate access token.\n"
+            "The Pixel ID above is reused as the dataset ID of the endpoint."
+        ),
+    )
+
+    def _retry_failed_facebook_capi_events(self):
+        """Cron: retry Conversions API payloads that failed on the first attempt.
+
+        Called once (not per website) so each pending record is processed
+        exactly once regardless of the number of websites. Payloads whose
+        ``event_time`` is older than 7 days are discarded (Meta hard limit).
+        """
+        max_attempts = 5
+        max_age_seconds = FACEBOOK_CAPI_MAX_EVENT_AGE_DAYS * 24 * 3600
+        now = int(time.time())
+
+        # Cap per run: each pending order does a blocking HTTP call, so a large
+        # backlog (e.g. after a Meta outage) drains across successive runs
+        # instead of one run running for hours and overlapping the next.
+        orders = self.env["sale.order"].sudo().search([("facebook_capi_pending_payload", "!=", False)], limit=200)
+        for order in orders:
+            payload = order.facebook_capi_pending_payload or {}
+            attempts = payload.get("_attempts", 0)
+            event_time = payload.get("event_time", 0)
+            too_old = event_time and (now - event_time) > max_age_seconds
+            if attempts >= max_attempts or too_old:
+                order.facebook_capi_pending_payload = False
+                continue
+            sent = order._send_facebook_capi_event(
+                payload.get("event_name", ""),
+                payload.get("custom_data", {}),
+                _is_retry=True,
+                event_time=event_time or None,
+            )
+            if sent:
+                order.facebook_capi_pending_payload = False

--- a/facebook_pixel_tracking/static/src/interactions/website_sale_tracking.js
+++ b/facebook_pixel_tracking/static/src/interactions/website_sale_tracking.js
@@ -1,8 +1,6 @@
  /** @odoo-module **/
 
-import { PaymentForm } from '@payment/interactions/payment_form';
 import { registry } from '@web/core/registry';
-import { patch } from '@web/core/utils/patch';
 import { Interaction } from '@web/public/interaction';
 
 export class FacebookPixelTracking extends Interaction {
@@ -17,7 +15,6 @@ export class FacebookPixelTracking extends Interaction {
      _pushInfo(event, dict){
         if(typeof(fbq) !== 'undefined'){
             fbq('track', event, dict);
-            console.log(dict);
         }
     }
 
@@ -84,40 +81,9 @@ export class FacebookPixelTracking extends Interaction {
 
 }
 
-
-//Heredamos PaymentForm form porque el metodo _submitForm tiene stopPropagation y preventDefault, impidiendonos hacerlo en el widget GoogleTagManagerAdvancedTracking
-
-patch(PaymentForm.prototype, {
-
-    _pushInfo(event, dict){
-        if(typeof(fbq) !== 'undefined'){
-            fbq('track', event, dict);
-            console.log(dict);
-        }
-    },
-
-
-    // @override
-    async submitForm(ev) {
-        const info_div = document.querySelector(".o_website_sale_checkout_container");
-        if (info_div) {
-            const info = JSON.parse(info_div.dataset.purchase_info || '{}');
-            const contents = (info.items || []).map(item => ({
-                id: String(item.item_id),
-                quantity: item.quantity,
-                item_price: item.price,
-            }));
-            const dict = {
-                value: info.value,
-                currency: info.currency,
-                content_ids: contents.map(item => item.id),
-                contents: contents,
-                content_type: 'product',
-            };
-            this._pushInfo('Purchase', dict);
-        }
-        super.submitForm(...arguments);
-    },
-})
+// The Purchase event is no longer emitted from the frontend: it is sent
+// server-side via the Meta Conversions API at sale.order confirmation
+// (see models/sale_order.py). This keeps a single source of truth and avoids
+// reporting purchases for carts that fail or are abandoned at the gateway.
 
 registry.category('public.interactions').add('facebook_pixel_tracking.FacebookPixelTracking', FacebookPixelTracking);

--- a/facebook_pixel_tracking/views/res_config_settings_view.xml
+++ b/facebook_pixel_tracking/views/res_config_settings_view.xml
@@ -22,15 +22,38 @@
                                 placeholder="1234567890"
                             />
                         </div>
-                    </div>
-                    <div>
-                        <a
-                            href="https://es-la.facebook.com/business/help/952192354843755?id=1205376682832142"
-                            class="oe_link fa fa-arrow-right"
-                            target="_blank"
-                        >
-                            Como obtengo mi codigo pixel
-                        </a>
+                        <div class="row">
+                            <div class="col-lg-4" />
+                            <a
+                                href="https://es-la.facebook.com/business/help/952192354843755?id=1205376682832142"
+                                class="oe_link fa fa-arrow-right"
+                                target="_blank"
+                            >
+                                ¿Cómo obtengo mi código píxel?
+                            </a>
+                        </div>
+                        <div class="row mt16">
+                            <label
+                                class="col-lg-4 o_light_label"
+                                for="facebook_capi_access_token"
+                                string="Conversions API Token"
+                            />
+                            <field
+                                name="facebook_capi_access_token"
+                                password="True"
+                                placeholder="EAAG..."
+                            />
+                        </div>
+                        <div class="row">
+                            <div class="col-lg-4" />
+                            <a
+                                href="https://developers.facebook.com/documentation/ads-commerce/conversions-api/get-started/?locale=es_ES#using-events-manager-recommended"
+                                class="oe_link fa fa-arrow-right"
+                                target="_blank"
+                            >
+                                ¿Cómo genero el token de la Conversion API?
+                            </a>
+                        </div>
                     </div>
                 </setting>
             </setting>


### PR DESCRIPTION
## Qué hace

Mueve el evento **Purchase** de `facebook_pixel_tracking` del frontend (`fbq`) al **server-side de Odoo** vía la **Meta Conversions API (CAPI)**, disparándolo en la confirmación real de la venta (`sale.order._action_confirm()`). El resto de los eventos (`AddToCart`, `InitiateCheckout`) siguen client-side sin cambios.

Replica el patrón ya implementado en `website_sale_google_analytics_4` (mismo hook, misma captura de datos en el checkout, mismo manejo de errores y cron de reintentos).

## Por qué

El Purchase de browser es frágil: se perdía cuando la redirección de la pasarela fallaba o había ad-blocker/ITP, y se inflaba porque se disparaba en el `submitForm` **antes** de confirmar el pago (carritos abandonados reportados como compras).

## Cambios principales

- `models/sale_order.py` (nuevo): campos de captura (`fb_fbp`, `fb_fbc`, ip, user-agent, event source url) + `facebook_capi_pending_payload`; envío a CAPI con `event_id=str(order.id)` para dedup, `user_data` hasheado SHA-256, `content_ids` como string; override de `_action_confirm`.
- `controllers/main.py` (nuevo): captura de identificadores de Meta durante `shop_checkout` (necesaria porque la confirmación puede llegar por webhook, sin request del cliente).
- `models/website.py`: `facebook_capi_access_token` + cron `_retry_failed_facebook_capi_events` (cada 15', hasta 5 intentos, descarta eventos > 7 días).
- `views/res_config_settings_view.xml`: token de Conversions API en Ajustes, junto al Pixel ID.
- `static/src/interactions/website_sale_tracking.js`: se elimina el `patch` que disparaba el Purchase prematuro.

## Configuración

`facebook_pixel_key` se reutiliza como dataset ID. Nuevo `facebook_capi_access_token` (Events Manager → Pixel → Settings → Conversions API). Si falta el token o el pixel, el envío server-side se saltea sin romper nada.

Task: 72761