### PR TITLE
[ADD] google_tag_manager_advanced_tracking: GA4 API Secret placeholder field

### DIFF
--- a/google_tag_manager_advanced_tracking/__manifest__.py
+++ b/google_tag_manager_advanced_tracking/__manifest__.py
@@ -25,10 +25,14 @@
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
     "depends": [
+        "website",
         "website_google_tag_manager",
         "website_sale_advanced_tracking",
     ],
-    "data": ["views/snippets.xml"],
+    "data": [
+        "views/snippets.xml",
+        "views/res_config_settings_view.xml",
+    ],
     "assets": {
         "web.assets_frontend": [
             "google_tag_manager_advanced_tracking/static/src/js/website_sale_tracking.js",

--- a/google_tag_manager_advanced_tracking/models/__init__.py
+++ b/google_tag_manager_advanced_tracking/models/__init__.py
@@ -2,4 +2,5 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from . import models
+from . import website
+from . import res_config_settings

--- a/google_tag_manager_advanced_tracking/models/res_config_settings.py
+++ b/google_tag_manager_advanced_tracking/models/res_config_settings.py
@@ -1,0 +1,16 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    ga4_api_secret = fields.Char(
+        string="GA4 API Secret",
+        related="website_id.ga4_api_secret",
+        readonly=False,
+        groups="base.group_system",
+    )

--- a/google_tag_manager_advanced_tracking/models/website.py
+++ b/google_tag_manager_advanced_tracking/models/website.py
@@ -1,0 +1,25 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    # Campo "dummy" (placeholder): en v18 solo almacena el valor. La integración
+    # GA4 server-side que lo consume vive en v19 (module website_sale_google_analytics_4,
+    # que define este mismo campo homónimo). Se agrega acá para que los clientes en
+    # v18 puedan generar y cargar su GA4 API Secret antes del pase de versión; el
+    # Upgrade Line de deprecación de GTM migra el valor al módulo nuevo. Ver tarea #66923.
+    ga4_api_secret = fields.Char(
+        string="GA4 API Secret",
+        copy=False,
+        groups="base.group_system",
+        help=(
+            "Measurement Protocol API Secret generated in GA4 admin.\n"
+            "Required to send server-side events (purchase, refund) after upgrading to v19.\n"
+            "Generate one at: Admin → Data Streams → your stream → Measurement Protocol API secrets."
+        ),
+    )

--- a/google_tag_manager_advanced_tracking/views/res_config_settings_view.xml
+++ b/google_tag_manager_advanced_tracking/views/res_config_settings_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        Add a GA4 API Secret (server-side) field in Website Settings, right after
+        the native Google Analytics (Measurement ID) setting. In v18 this is a
+        placeholder so clients can load the value before upgrading to v19, where
+        website_sale_google_analytics_4 consumes it. See task #66923.
+    -->
+    <record id="res_config_settings_view_form_ga4_secret" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.ga4_api_secret</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@id='google_analytics_setting']" position="after">
+                <setting
+                    id="ga4_api_secret_setting"
+                    string="GA4 API Secret (Server-side)"
+                    invisible="not has_google_analytics"
+                    help="Measurement Protocol API Secret for server-side purchase and refund events. Generate at: GA4 Admin → Data Streams → your stream → Measurement Protocol API secrets."
+                >
+                    <div class="content-group">
+                        <div class="row mt16">
+                            <label class="col-lg-4 o_light_label" for="ga4_api_secret"/>
+                            <field name="ga4_api_secret" password="True" placeholder="Your API secret"/>
+                        </div>
+                    </div>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Qué

Agrega un campo `ga4_api_secret` (Char) en `website`, su related en
`res.config.settings` y el setting correspondiente bajo **Website → Tracking &
SEO**, justo debajo del setting nativo de Google Analytics.

Espeja el campo homónimo que en 19.0 define `website_sale_google_analytics_4`.

## Por qué

En v18 el campo es un *placeholder*: solo almacena el valor. Permite que los
clientes que hoy están en 18.0 generen y carguen su **GA4 Measurement Protocol
API Secret (server-side)** antes de actualizar a 19.0, donde
`website_sale_google_analytics_4` lo consume para los eventos server-side
(purchase, refund).

Durante el pase v18→v19, el Upgrade Line de deprecación del stack GTM migra el
valor al campo homónimo del módulo nuevo. Mantener el **mismo nombre técnico**
(`website.ga4_api_secret`) es lo que hace que la columna sea reutilizable y el
dato no se pierda.

## Test plan

- Instalar/actualizar `google_tag_manager_advanced_tracking` en una base 18.0.
- Ir a **Ajustes → Sitio web → Tracking & SEO**: con Google Analytics activo,
  aparece **GA4 API Secret (Server-side)** con su input.
- Cargar un valor y guardar; verificar que persiste en `website.ga4_api_secret`.

Task: https://www.adhoc.inc/odoo/project.task/66923